### PR TITLE
Steer update 170202

### DIFF
--- a/examples/PandoraSettings/PandoraSettingsDefault.xml
+++ b/examples/PandoraSettings/PandoraSettingsDefault.xml
@@ -389,6 +389,7 @@
     </algorithm>
 
     <algorithm type = "MuonClusterAssociation">
+        <TargetClusterListName>PrimaryClusters</TargetClusterListName>
         <MuonClusterListName>MuonRemovedYokeClusters</MuonClusterListName>
     </algorithm>
 

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -187,6 +187,7 @@
 
   <!-- == TruthTrackFinder parameters == -->
   <processor name="MyTruthTrackFinder" type="TruthTrackFinder">
+    <parameter name="FitForward" type="bool">true</parameter>
     <!--Define input tracker hits and relations. NB. Order must be respected -->
     <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDTrackerHits ITrackerHits OTrackerHits VXDEndcapTrackerHits ITrackerEndcapHits OTrackerEndcapHits</parameter>
     <parameter name="SimTrackerHitRelCollectionNames" type="StringVec" lcioInType="LCRelation">VXDTrackerHitRelations InnerTrackerBarrelHitsRelations OuterTrackerBarrelHitsRelations VXDEndcapTrackerHitRelations InnerTrackerEndcapHitsRelations OuterTrackerEndcapHitsRelations </parameter>


### PR DESCRIPTION
update PandoraSettings file, reflecting changes in the MuonClusterAssociation algorithm.

Update in the reconstruction steering file: 
change the direction of the fit in TruthTracking for improved performance for models CLIC_o3_v07 and CLIC_o3_v08