### PR TITLE
Reconstruction::MuonReco: adapt parameters to smaller number of layers

### DIFF
--- a/examples/PandoraSettings/PandoraSettingsDefault.xml
+++ b/examples/PandoraSettings/PandoraSettingsDefault.xml
@@ -41,6 +41,9 @@
             <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
             <TrackPathWidth>0</TrackPathWidth>
         </algorithm>
+	<MinClusterOccupiedLayers>5</MinClusterOccupiedLayers>
+	<MinClusterLayerSpan>5</MinClusterLayerSpan>
+
         <!-- Input lists -->
         <InputTrackListName>Tracks</InputTrackListName>
         <InputCaloHitListName>CaloHits</InputCaloHitListName>


### PR DESCRIPTION

BEGINRELEASENOTES
- Reconstruction::MuonReconstruction change number of required layers for muon identification to reflect smaller number of layers in the muon system. Increases Muon ID efficiency

ENDRELEASENOTES