### PR TITLE
[Request for Comments] Allow steering of reconstruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,12 +97,12 @@ ENDIF()
 #ADD_DEFINITIONS( "-Wno-long-long" )
 
 # include directories
-INCLUDE_DIRECTORIES( ./Calorimetry/include ./Tracking/include )
-#INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
+INCLUDE_DIRECTORIES( ./Calorimetry/include ./Tracking/include source/Conditions/include )
 
 # add library
 AUX_SOURCE_DIRECTORY(./Calorimetry/src library_sources )
 AUX_SOURCE_DIRECTORY(./Tracking/src library_sources )
+AUX_SOURCE_DIRECTORY(./source/Conditions/src library_sources )
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -9,10 +9,27 @@ ADD_TEST( NAME t_${test_name}
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
-SET( test_name "test_CLIC_o3_v11_reco" )
+SET( test_name "test_CLIC_o3_v11_reco_truth" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Truth
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+
+SET( test_name "test_CLIC_o3_v11_reco_conformal" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Conformal
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+SET( test_name "test_CLIC_o3_v11_reco_overlay" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -57,9 +57,68 @@
     <!--InitializeDD4hep reads a compact xml file and initializes the DD4hep::LCDD object-->
     <!--Name of the DD4hep compact xml file to load-->
     <parameter name="EncodingStringParameter"> GlobalTrackerReadoutID </parameter>
-    <parameter name="DD4hepXMLFile" type="string"> /afs/cern.ch/user/s/simoniel/public/ForEmilia/CLIC_o2_v04/CLIC_o2_v04.xml </parameter>
+    <parameter name="DD4hepXMLFile" type="string">
+      /cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+    </parameter>
   </processor>
 
+
+  <processor name="Overlay3TeV" type="OverlayTimingGeneric">
+    <!--Processor to overlay events from the background taking the timing of the subdetectors into account-->
+    <!--Name of the lcio input file(s) with background - assume one file per bunch crossing.-->
+    <parameter name="BackgroundFileNames" type="StringVec">
+      gghad_01.slcio
+      gghad_02.slcio
+    </parameter>
+    <!--The MC Particle Collection Name-->
+    <parameter name="MCParticleCollectionName" type="string">MCParticle </parameter>
+    <!--The output MC Particle Collection Name for the physics event-->
+    <parameter name="MCPhysicsParticleCollectionName" type="string"> MCPhysicsParticles </parameter>
+    <!--Time difference between bunches in the bunch train in ns-->
+    <parameter name="Delta_t" type="float" value="0.5"/>
+    <!--Number of bunches in a bunch train-->
+    <parameter name="NBunchtrain" type="int" value="60"/>
+    <!--Number of Background events to overlay - either fixed or Poisson mean-->
+    <parameter name="NumberBackground" type="float" value="3.2"/>
+    <!--Number of the Bunch crossing of the physics event-->
+    <parameter name="PhysicsBX" type="int" value="10"/>
+    <!--Draw random number of Events to overlay from Poisson distribution with  mean value NumberBackground-->
+    <parameter name="Poisson_random_NOverlay" type="bool" value="true"/>
+    <!--Place the physics event at an random position in the train - overrides PhysicsBX-->
+    <parameter name="RandomBx" type="bool" value="false"/>
+    <!--random seed - default 42-->
+    <parameter name="RandomSeed" type="int" value="42"/>
+    <!--[mm/ns] (float) - default 5.0e-2 (5cm/us)-->
+    <parameter name="TPCDriftvelocity" type="float" value="0.05"/>
+
+    <parameter name="Collection_IntegrationTimes" type="StringVec" >
+      VertexBarrelCollection        10
+      VertexEndcapCollection        10
+
+      InnerTrackerBarrelCollection  10
+      InnerTrackerEndcapCollection  10
+
+      OuterTrackerBarrelCollection  10
+      OuterTrackerEndcapCollection  10
+
+      ECalBarrelCollection          10
+      ECalEndcapCollection          10
+      ECalPlugCollection            10
+
+      HCalBarrelCollection          10
+      HCalEndcapCollection          10
+      HCalRingCollection            10
+
+      YokeBarrelCollection          10
+      YokeEndcapCollection          10
+
+      LumiCalCollection             10
+      BeamCalCollection             10
+    </parameter>
+
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!--parameter name="Verbosity" type="string" value=""/-->
+  </processor>
 
   <processor name="VXDBarrelDigitiser" type="DDPlanarDigiProcessor">
     <parameter name="SubDetectorName" type="string">Vertex </parameter>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -5,6 +5,11 @@
     <!-- ========== setup  ========== -->
     <processor name="MyAIDAProcessor"/>
     <processor name="InitDD4hep"/>
+    <processor name="Config" />
+
+    <if condition="Config.Overlay3TeV">
+      <processor name="Overlay3TeV"/>
+    </if>
 
     <!-- ========== digitisation  ========== -->
     <processor name="VXDBarrelDigitiser"/>
@@ -16,10 +21,14 @@
 
     <!-- ========== tracking  ========== -->
     <!-- At the moment the name of the final track collection for the MyTruthTrackFinder and MyExtrToTracker processors is the same, so that users can use this example to run easily both the cheater track pattern recognition (still the default for many tasks) or the real one (under final tests) -->
-    <processor name="MyTruthTrackFinder"/>
-    <!-- <processor name="MyDDCellsAutomatonMV"/>  --> <!-- alternative to the ConformalTracking, but only in the vertex barrel region! -->
-    <!-- <processor name="MyConformalTracking"/> -->
-    <!-- <processor name="MyExtrToTracker"/> -->
+    <if condition="Config.TruthTracking">
+      <processor name="MyTruthTrackFinder"/>
+    </if>
+
+    <if condition="Config.ConformalTracking">
+      <processor name="MyConformalTracking"/>
+      <processor name="MyExtrToTracker"/>
+    </if>
 
     <!-- === calorimeter digitization and pandora reco === -->
     <processor name="MyDDCaloDigi"/>
@@ -62,6 +71,12 @@
     </parameter>
   </processor>
 
+  <processor name="Config" type="CLICRecoConfig" >
+    <!--Which option to use for overlay: False, 3TeV, 380GeV. Then use, e.g., Config.Overlay3TeV in the condition-->
+    <parameter name="Overlay" type="string">False </parameter>
+    <!--Which option to use for tracking: Truth, Conformal-->
+    <parameter name="Tracking" type="string">Truth </parameter>
+  </processor>
 
   <processor name="Overlay3TeV" type="OverlayTimingGeneric">
     <!--Processor to overlay events from the background taking the timing of the subdetectors into account-->

--- a/source/Conditions/include/CLICRecoConfig.h
+++ b/source/Conditions/include/CLICRecoConfig.h
@@ -23,6 +23,7 @@ public:
 
   // Run over each event - the main algorithm
   virtual void modifyEvent( LCEvent* evt ) ;
+  virtual void processEvent( LCEvent* evt ) ;
 
   // Run at the end of each event
   virtual void check( LCEvent* evt ) ;

--- a/source/Conditions/include/CLICRecoConfig.h
+++ b/source/Conditions/include/CLICRecoConfig.h
@@ -1,0 +1,64 @@
+#ifndef CLICRecoConfig_h
+#define CLICRecoConfig_h 1
+
+#include "marlin/Processor.h"
+#include "marlin/EventModifier.h"
+
+class CLICRecoConfig : public marlin::Processor, public marlin::EventModifier {
+
+public:
+
+  virtual marlin::Processor*  newProcessor() { return new CLICRecoConfig; }
+  virtual std::string const& name() const { return marlin::Processor::name(); };
+
+  CLICRecoConfig() ;
+  CLICRecoConfig(const CLICRecoConfig&) = delete;
+  CLICRecoConfig& operator=(const CLICRecoConfig&) = delete;
+
+  // Initialisation - run at the beginning to start histograms, etc.
+  virtual void init() ;
+
+  // Called at the beginning of every run
+  virtual void processRunHeader( LCRunHeader* run ) ;
+
+  // Run over each event - the main algorithm
+  virtual void modifyEvent( LCEvent* evt ) ;
+
+  // Run at the end of each event
+  virtual void check( LCEvent* evt ) ;
+
+  // Called at the very end for cleanup, histogram saving, etc.
+  virtual void end() ;
+
+protected:
+
+  // Parameters
+  const std::vector< std::string > m_trackingPossibleOptions{ "Truth", "Conformal" };
+  std::string m_trackingOption="Truth";
+
+  // Parameters
+  std::vector< std::string > m_overlayPossibleOptions{ "False", "3TeV", "380GeV" };
+  std::map<std::string, bool> m_overlay{};
+  std::string m_overlayChoice="False";
+
+  bool m_truthTracking = true;
+  bool m_conformalTracking = false;
+
+
+protected:
+  void checkOptions( std::string const& optionValue, std::vector<std::string> const& options ) const;
+
+  template< class T > static void toString( std::stringstream& stream, std::vector<T> const& vector) {
+    unsigned int counter = 0;
+    for (auto const& entry: vector) {
+      stream << entry;
+      if( counter < vector.size() - 1 ) {
+        stream << ", ";
+      }
+      counter++;
+    }
+  }
+
+} ;
+
+#endif

--- a/source/Conditions/src/CLICRecoConfig.cc
+++ b/source/Conditions/src/CLICRecoConfig.cc
@@ -1,0 +1,108 @@
+#include "CLICRecoConfig.h"
+
+#include <iomanip>
+
+
+CLICRecoConfig aCLICRecoConfig;
+
+CLICRecoConfig::CLICRecoConfig() : Processor("CLICRecoConfig") {
+
+  // modify processor description
+  _description = "CLICRecoConfig allows one to configure the processors to run via command line" ;
+
+  std::stringstream trackingOptionDescription;
+  trackingOptionDescription << "Which option to use for tracking: ";
+  toString( trackingOptionDescription, m_trackingPossibleOptions );
+
+  registerProcessorParameter("Tracking",
+                             trackingOptionDescription.str(),
+                             m_trackingOption,
+                             m_trackingOption);
+
+
+  std::stringstream overlayOptionDescription;
+  overlayOptionDescription << "Which option to use for overlay: ";
+  toString( overlayOptionDescription, m_overlayPossibleOptions );
+  overlayOptionDescription <<". Then use, e.g., Config.Overlay3TeV in the condition";
+  registerProcessorParameter("Overlay",
+                             overlayOptionDescription.str(),
+                             m_overlayChoice,
+                             m_overlayChoice);
+
+}
+
+
+void CLICRecoConfig::init() {
+
+  // Print the initial parameters
+  printParameters() ;
+
+  checkOptions( m_trackingOption, m_trackingPossibleOptions );
+
+  if( m_trackingOption == "Truth" ) {
+
+    m_truthTracking = true;
+    m_conformalTracking = false;
+
+  } else if( m_trackingOption == "Conformal" ) {
+
+    m_truthTracking = false;
+    m_conformalTracking = true;
+
+  }
+
+
+
+  // Treat option for overlay
+  checkOptions( m_overlayChoice, m_overlayPossibleOptions );
+
+  //fill map with overlay options
+  for ( auto& overlayEnergy: m_overlayPossibleOptions ) {
+    if( overlayEnergy == "False" ){ continue; }
+    m_overlay["Overlay"+ overlayEnergy] = (overlayEnergy == m_overlayChoice);
+  }
+
+  for ( auto& overlayEnergy: m_overlay ) {
+    streamlog_out(MESSAGE) << std::setw(15) << overlayEnergy.first << " "
+                           << std::boolalpha << overlayEnergy.second  << std::endl;
+  }
+
+}
+
+void CLICRecoConfig::processRunHeader( LCRunHeader* ){}
+
+void CLICRecoConfig::modifyEvent( LCEvent* ) {
+  streamlog_out(MESSAGE) << "Running Config" << std::endl;
+
+  setReturnValue( "TruthTracking", m_truthTracking );
+  setReturnValue( "ConformalTracking", m_conformalTracking );
+
+  for (auto const& over : m_overlay) {
+    setReturnValue( over.first, over.second );
+  }
+
+}
+
+void CLICRecoConfig::check( LCEvent* ){}
+
+
+void CLICRecoConfig::end(){}
+
+void CLICRecoConfig::checkOptions( std::string const& optionValue, std::vector<std::string> const& options ) const {
+
+  bool validOption = false;
+  for(auto const& opt : options) {
+    if( optionValue == opt) {
+      validOption = true;
+      break;
+    }
+  }
+  if( not validOption ){
+    std::stringstream errorMessage;
+    errorMessage << "Invalid option value '" << optionValue << "'. Use one of [";
+    toString( errorMessage, options );
+    errorMessage << "]!";
+    throw std::runtime_error( errorMessage.str() );
+  }
+
+}

--- a/source/Conditions/src/CLICRecoConfig.cc
+++ b/source/Conditions/src/CLICRecoConfig.cc
@@ -71,6 +71,11 @@ void CLICRecoConfig::init() {
 
 void CLICRecoConfig::processRunHeader( LCRunHeader* ){}
 
+void CLICRecoConfig::processEvent( LCEvent* ) {
+  modifyEvent( nullptr );
+}
+
+
 void CLICRecoConfig::modifyEvent( LCEvent* ) {
   streamlog_out(MESSAGE) << "Running Config" << std::endl;
 


### PR DESCRIPTION
Needs: ilcsoft/Marlin#11; contains #16 and thus needs ilcsoft/Overlay#6.

This would allow one to chose which reconstruction to run based on command line arguments (or less changes in the steering file)
Command line:
```
Marlin clicReconstruction.xml  --Config.Tracking=Truth  --Config.Overlay=3TeV
```
Steering File
```
    <parameter name="Tracking" type="String"> Truth </parameter>
    <parameter name="Overlay" type="String"> False </parameter>
```

BEGINRELEASENOTES
- Add CLICRecoConfig processor to chose which configuration to use for reconstruction: truth conformal tracking, if and which overlay

ENDRELEASENOTES