### PR TITLE
Fixes for HitResidual Processor

### DIFF
--- a/Tracking/include/HitResiduals.h
+++ b/Tracking/include/HitResiduals.h
@@ -85,6 +85,7 @@ class HitResiduals : public Processor {
   std::vector<double > _resV = {};
   std::vector<int > _subdet = {};
   std::vector<int > _layer = {};
+  std::vector<int > _side = {};
 
   MarlinTrk::IMarlinTrkSystem* _trksystem = NULL;
   SurfaceMap _surfMap = {};

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -133,7 +133,7 @@ void HitResiduals::init() {
   _tree->Branch("resV", "std::vector<double >",&_resV,bufsize,0);
   _tree->Branch("subdet", "std::vector<int >",&_subdet,bufsize,0);
   _tree->Branch("layer", "std::vector<int >",&_layer,bufsize,0);
- 
+  _tree->Branch("side", "std::vector<int >",&_side,bufsize,0);
 
 
   //lcdd and bfield
@@ -189,7 +189,7 @@ void HitResiduals::processEvent( LCEvent * evt ) {
   _resV.clear();
   _subdet.clear();
   _layer.clear();
-
+  _side.clear();
 
 
   UTIL::BitField64 cellid_decoder( lcio::LCTrackerCellID::encoding_string() ) ; 	    
@@ -229,12 +229,16 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 	streamlog_out(DEBUG1) << "id = " << id << std::endl;
 
 	int layer = cellid_decoder["layer"].value();
-	int subdet = cellid_decoder["subdet"].value();
+	int subdet = cellid_decoder["system"].value();
+	int side = cellid_decoder["side"].value();
 	streamlog_out(DEBUG1) << "layer = " << layer << std::endl;
 	streamlog_out(DEBUG1) << "subdet = " << subdet << std::endl;
+	streamlog_out(DEBUG1) << "side = " << side << std::endl;
 
 	encoder[lcio::LCTrackerCellID::subdet()] = subdet;
-	encoder[lcio::LCTrackerCellID::layer()]  = layer;   
+	encoder[lcio::LCTrackerCellID::layer()] = layer; 
+	encoder[lcio::LCTrackerCellID::side()] = side;
+
 	layerID = encoder.lowWord();  
 	streamlog_out(DEBUG1) << "layerID = " << layerID << std::endl;
 
@@ -275,6 +279,7 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 	  _resV.push_back(resV);
 	  _subdet.push_back(subdet);
 	  _layer.push_back(layer);
+	  _side.push_back(side);
 
  	} else streamlog_out(DEBUG4) << "FAIL" << std::endl;
      


### PR DESCRIPTION
BEGINRELEASENOTES
* HitResiduals: replaced 'subdet' with 'system' in the call to the encoding string (otherwise the processor won't work) and added the 'side' information needed to propagateToLayer when hits are in the endcaps.

ENDRELEASENOTES