### PR TITLE
add tests running Valgrind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ FOREACH( pkg Marlin MarlinUtil GSL AIDA )
 	ENDIF()
 ENDFOREACH()
 
+OPTION( VALGRIND "Set to location of valgrind" "/cvmfs/sft.cern.ch/lcg/releases/LCG_88/valgrind/3.11.0/x86_64-centos7-gcc62-opt/bin/valgrind" )
+OPTION( VALGRIND_LIB "Set to location of lib[64]/valgrind" "/cvmfs/sft.cern.ch/lcg/releases/LCG_88/valgrind/3.11.0/x86_64-centos7-gcc62-opt/lib/valgrind" )
 
 
 ### DOCUMENTATION ###########################################################

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -37,8 +37,9 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 
 SET( test_name "test_CLIC_o2_v04_reco_conformal_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
-  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  ${VALGRIND} --leak-check=full --show-leak-kinds=all --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp Marlin --InitDD4hep.DD4hepXMLFile=CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=10  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v04.slcio
+  COMMAND
+  ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
+  ${VALGRIND} --leak-check=full --show-leak-kinds=all --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp Marlin --InitDD4hep.DD4hepXMLFile=CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=10  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v04.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -49,7 +50,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_sim" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
-  ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --runType=batch -G -N=20 --outputFile=testCLIC_o3_v11.slcio --gun.isotrop=true --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
+  ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --runType=batch -G -N=100 --outputFile=testCLIC_o3_v11.slcio --gun.isotrop=true --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
@@ -57,7 +58,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_truth" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Truth
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Truth --global.MaxRecordNumber=3 --MyLCIOOutputProcessor.LCIOOutputFile=reco_truthl_v11.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -66,7 +67,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_conformal" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Conformal
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Conformal --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_conformal_v11.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -74,7 +75,37 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_overlay" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_v11.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+SET( test_name "test_CLIC_o3_v11_reco_overlay_valgrind" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND
+  ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
+  ${VALGRIND} --leak-check=full --show-leak-kinds=all
+  --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
+  --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
+  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_v11.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+SET( test_name "test_CLIC_o3_v11_reco_conformal_overlay_valgrind" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND
+  ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
+  ${VALGRIND} --leak-check=full --show-leak-kinds=all
+  --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
+  --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
+  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v11.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,51 @@
 
 
 
+SET( test_name "test_CLIC_o2_v04_sim" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
+  ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --runType=batch -G -N=100 --outputFile=testCLIC_o2_v04.slcio --gun.isotrop=true --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
+
+SET( test_name "test_CLIC_o2_v04_reco_truth" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Tracking=Truth --global.MaxRecordNumber=3 --MyLCIOOutputProcessor.LCIOOutputFile=reco_truth.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+
+SET( test_name "test_CLIC_o2_v04_reco_conformal" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Tracking=Conformal --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_conformal.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+SET( test_name "test_CLIC_o2_v04_reco_overlay" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+
+SET( test_name "test_CLIC_o2_v04_reco_conformal_overlay_valgrind" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  ${VALGRIND} --leak-check=full --show-leak-kinds=all --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp Marlin --InitDD4hep.DD4hepXMLFile=CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=10  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v04.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
+
+
+
 SET( test_name "test_CLIC_o3_v11_sim" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"

--- a/Tests/bin/ValgrindTests.sh
+++ b/Tests/bin/ValgrindTests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Simple script to run marlin tests with valgrind on top
+#   calls the command (given as first argument)
+#   with all following arguments
+#
+
+#----- initialize environment for this package - including DD4hep
+
+#----- parse command line - first argument is the
+#      test to run
+## Drop existing ClicPerformance from MARLIN_DLL
+MARLIN_DLL=`echo $MARLIN_DLL | sed -e 's/:\?[-a-z0-9A-Z_/.]*libClicPerformance.so[.0-9]*:\?/:/'`
+export MARLIN_DLL=$1:$MARLIN_DLL
+export VALGRIND_LIB=$2
+command=$3
+theargs=""
+
+##Drop three
+shift
+shift
+shift
+for i in "$@" ; do
+    theargs="${theargs} $i"
+done
+
+echo " #### MARLIN_DLL = :  ${MARLIN_DLL}"
+
+echo " ### running test :  '${command} ${theargs}'"
+exec ${command} ${theargs}

--- a/etc/extra-root.supp
+++ b/etc/extra-root.supp
@@ -1,0 +1,6 @@
+## suppress uninitialised value in, e.g., TMatrixH https://sft.its.cern.ch/jira/browse/ROOT-8484
+{
+  TObject::operator=(const TObject&) uses uninitialized value in IsOnHeap()
+  Memcheck:Cond
+  fun:_ZN7TObjectaSERKS_
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- tests running valgrind:
    By default uses valgrind from /cvmfs/sft
      to run:
        `ctest -C valgrind -R _testName_`
     See test names via `ctest -C valgrind -N`
- Added option to run tests for CLIC_o2_v04 model for faster debugging 
   E.g.: `ctest -C o2_v04 -R o2_v04 -E valgrind`
  needs special steering file without GlobalTrackerReadoutID specified

- Add suppressions file for valgrind to use in addition to root suppressions file for uninitialised member in a TObject

ENDRELEASENOTES