### PR TITLE
Cleanup

### DIFF
--- a/Tracking/include/HitResiduals.h
+++ b/Tracking/include/HitResiduals.h
@@ -76,7 +76,6 @@ class HitResiduals : public Processor {
   std::string _outFileName = "";
   std::string _treeName = "";
 
-  TFile* _out = NULL;
   TTree* _tree = NULL;
 
   int _nRun = 0;

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -306,7 +306,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
   for(int itTrack=0;itTrack<nTracks;itTrack++){
     
     // Get the track
-    Track* track = dynamic_cast<Track*>( trackCollection->getElementAt(itTrack) ) ;
+    Track* track = static_cast<Track*>( trackCollection->getElementAt(itTrack) ) ;
     
     // Get the hits
     const TrackerHitVec& hitVector = track->getTrackerHits();
@@ -326,7 +326,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     int nHits = hitVector.size();
     for(int itHit=0;itHit<nHits;itHit++){
       // Get the tracker hit
-      TrackerHitPlane* hit = dynamic_cast<TrackerHitPlane*>(hitVector.at(itHit));
+      TrackerHitPlane* hit = static_cast<TrackerHitPlane*>(hitVector.at(itHit));
       // Get the subdetector number
       int subdetector = getSubdetector(hit,m_encoder);
       // Check if this subdetector is to be included in the efficiency calculation
@@ -337,7 +337,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
       // Get the simulated hit
       const LCObjectVec& simHitVector = relations[subdetector]->getRelatedToObjects( hit );
       // Take the first hit only (this should be changed? Yes - loop over all related simHits and add an entry for each mcparticle so that this hit is in each fit)
-      SimTrackerHit* simHit = dynamic_cast<SimTrackerHit*>(simHitVector.at(0));
+      SimTrackerHit* simHit = static_cast<SimTrackerHit*>(simHitVector.at(0));
       // Get the particle belonging to that hit
       MCParticle* particle = simHit->getMCParticle();
       // Check if this particle already has hits on this track
@@ -409,13 +409,13 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     for(int itHit=0;itHit<nHits;itHit++){
       
       // Get the hit
-      TrackerHitPlane* hit = dynamic_cast<TrackerHitPlane*>( trackerHitCollections[collection]->getElementAt(itHit) ) ;
+      TrackerHitPlane* hit = static_cast<TrackerHitPlane*>( trackerHitCollections[collection]->getElementAt(itHit) ) ;
       
       // Get the related simulated hit(s)
       const LCObjectVec& simHitVector = relations[collection]->getRelatedToObjects( hit );
       
       // Take the first hit only (this should be changed? Yes - loop over all related simHits and add an entry for each mcparticle so that this hit is in each fit)
-      SimTrackerHit* simHit = dynamic_cast<SimTrackerHit*>(simHitVector.at(0));
+      SimTrackerHit* simHit = static_cast<SimTrackerHit*>(simHitVector.at(0));
       
       // Get the particle belonging to that hit
       MCParticle* particle = simHit->getMCParticle();
@@ -439,7 +439,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     
     // Get the particle
     nCloseTrk=0;
-    MCParticle* particle = dynamic_cast<MCParticle*>( particleCollection->getElementAt(itParticle) ) ;
+    MCParticle* particle = static_cast<MCParticle*>( particleCollection->getElementAt(itParticle) ) ;
     
     // Calculate the particle properties
     TLorentzVector particleVector;
@@ -493,7 +493,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     // Check for particles close to each other (needs cleaning up FIXME)
     for(int j=0; j<nParticles; j++){
       if (itParticle!=j){
-        MCParticle* particle2 = dynamic_cast<MCParticle*>( particleCollection->getElementAt(j) );
+        MCParticle* particle2 = static_cast<MCParticle*>( particleCollection->getElementAt(j) );
         bool part2IsCharge = fabs(particle2->getCharge()) > 0.5;
         bool part2IsStable = particle2->getGeneratorStatus() == 1 ;
         if ( part2IsCharge && part2IsStable ) {
@@ -622,7 +622,7 @@ void ClicEfficiencyCalculator::getCollection(LCCollection* &collection, std::str
 }
 
 int ClicEfficiencyCalculator::getSubdetector(LCCollection* collection, UTIL::BitField64 &encoder){
-  TrackerHitPlane* hit = dynamic_cast<TrackerHitPlane*>( collection->getElementAt(0) ) ;
+  TrackerHitPlane* hit = static_cast<TrackerHitPlane*>( collection->getElementAt(0) ) ;
   const int celId = hit->getCellID0() ;
   encoder.setValue(celId) ;
   int subdet = encoder[lcio::LCTrackerCellID::subdet()];

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -288,7 +288,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
   // Make objects to hold all of the tracker hit and relation collections
   std::map<int,LCCollection*> trackerHitCollections;
   std::map<int,LCCollection*> trackerHitRelationCollections;
-  std::map<int,LCRelationNavigator*> relations;
+  std::map<int,std::shared_ptr<LCRelationNavigator> > relations;
   std::map<int,bool> activeDetectors;
   
   // Loop over each input collection and get the data
@@ -306,7 +306,8 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     getCollection(trackerHitRelationCollection, m_inputTrackerHitRelationCollections[collection], evt);
     
     // Create the relations navigator
-    LCRelationNavigator* relation = new LCRelationNavigator( trackerHitRelationCollection );
+    std::shared_ptr<LCRelationNavigator> relation =
+      std::make_shared<LCRelationNavigator>( LCRelationNavigator( trackerHitRelationCollection ) );
     
     // Get the subdetector for this set of collections
     int subdetector = getSubdetector(trackerHitCollection,m_encoder);

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -233,9 +233,7 @@ void ClicEfficiencyCalculator::processRunHeader( LCRunHeader* ) {
 
 void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
   
-  // Clean the trees
   std::cout<<"Processing event "<<m_eventNumber<<std::endl;
-  clearTreeVar();
   
   // First pick up all of the collections that will be used - tracks, MCparticles, hits from relevent subdetectors - and their relations
   
@@ -399,10 +397,6 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
    map, with the key a pointer to the MC particle. We can then loop over each
    MC particle at the end and get all of the hits, before making a track.
    */
-  
-  // Make the container
-  //std::map<MCParticle*, std::vector<TrackerHit*> > particleHits;
-  particleHits.clear();
   
   // Loop over all input collections
   for(unsigned int itCollection=0; itCollection<m_collections.size();itCollection++){
@@ -584,7 +578,10 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
   // Increment the event number
   std::cout<<"For this event reconstructed "<<100.*(double)nReconstructed/(double)nReconstructable<<" % ("<<nReconstructed<<"/"<<nReconstructable<<")"<<std::endl;
   m_eventNumber++ ;
-  
+
+  // Clean the trees
+  clearTreeVar();
+
 }
 
 void ClicEfficiencyCalculator::check( LCEvent *  ) {
@@ -872,6 +869,8 @@ void ClicEfficiencyCalculator::clearTreeVar(){
   m_vec_phi.clear();
   m_vec_p.clear();
   
+  particleHits.clear();
+
 }  
 
 

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -2,53 +2,27 @@
 #include "ClicEfficiencyCalculator.h"
 #include "DDRec/API/IDDecoder.h"
 
-#include "MarlinTrk/MarlinTrkUtils.h"
-#include "MarlinTrk/HelixTrack.h"
-#include "MarlinTrk/HelixFit.h"
-#include "MarlinTrk/IMarlinTrack.h"
-#include "MarlinTrk/Factory.h"
-#include "MarlinTrk/MarlinTrkDiagnostics.h"
-#include "MarlinTrk/IMarlinTrkSystem.h"
 #include "marlin/AIDAProcessor.h"
 
-#include <UTIL/CellIDDecoder.h>
 #include <EVENT/LCCollection.h>
+#include <EVENT/SimTrackerHit.h>
+
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCRelationImpl.h>
-#include <EVENT/SimTrackerHit.h>
-#include <IMPL/TrackerHitPlaneImpl.h>
 #include <IMPL/TrackImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
 
-#include <UTIL/CellIDEncoder.h>
+#include <UTIL/CellIDDecoder.h>
 #include <UTIL/LCTrackerConf.h>
-#include <UTIL/BitSet32.h>
 #include <UTIL/LCRelationNavigator.h>
 
 #include <marlinutil/GeometryUtil.h>
-
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_randist.h>
-
-#include "marlin/ProcessorEventSeeder.h"
-#include "marlin/Global.h"
-
-#include "CLHEP/Vector/TwoVector.h"
 
 #include <AIDA/IAnalysisFactory.h>
 #include <AIDA/IHistogramFactory.h>
 
 #include <TLorentzVector.h>
-#include "TFile.h"
-#include "TTree.h"
-
-#include <cmath>
-#include <algorithm>
-#include <sstream>
-#include <iostream>
-#include <climits>
-#include <cfloat>
-#include "sys/types.h"
-#include "sys/sysinfo.h"
+#include <TTree.h>
 
 
 using namespace lcio ;
@@ -184,8 +158,6 @@ void ClicEfficiencyCalculator::init() {
   // Initialise histograms
   AIDAProcessor::histogramFactory(this);
 
-  // Register this process
-  Global::EVENTSEEDER->registerProcessor(this);
   
   // Set up trees if ntuple output enabled
   if(m_fullOutput){

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -473,7 +473,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     m_thetaPtMCParticle->Fill(mcTheta,mcPt);
     std::vector<TrackerHit*> trackHits = particleHits[particle];
     int uniqueHits = getUniqueHits(trackHits,m_encoder);
-    int nHitsOnTrack(0);
+    //int nHitsOnTrack(0);
 
     // Check if it was reconstructed
     bool reconstructed=false;
@@ -676,18 +676,19 @@ bool ClicEfficiencyCalculator::isReconstructable(MCParticle*& particle, std::str
     //(a.t.m. no same cut on reco pT/theta but no bias because in that case also the mc particle is kept)
     
     //add condition for decay outside vertex/tracker?
-    bool isCharge = false;
+    //bool isCharge = false;
     bool isStable = false;
     bool passPt = false;
     bool passTheta = false;
     bool passNHits = false;
-    bool passIP = false;
-    bool passEndPoint = false;
+    //bool passIP = false;
+    //bool passEndPoint = false;
     // bool isOverlay = particle->isOverlay();
     // if (isOverlay) std::cout<<"----- ehi there are overlay particles in this mc collection"<<std::endl;
-    
-    double charge = fabs(particle->getCharge());
-    if (charge>0.5) isCharge = true;
+
+    // //isCharge Cut
+    // double charge = fabs(particle->getCharge());
+    // if (charge>0.5) isCharge = true;
     //else std::cout<<"----- mc not charged"<<std::endl;
     int genStatus = particle->getGeneratorStatus();
     //int nDaughters = particle->getDaughters().size();
@@ -715,13 +716,17 @@ bool ClicEfficiencyCalculator::isReconstructable(MCParticle*& particle, std::str
     // }
     // if (nVXDHits >= 4) return true;
     
-    double dist = sqrt( pow(particle->getVertex()[0],2) + pow(particle->getVertex()[1],2) );
-    if (dist<100.) passIP = true;
+    // //passIP Cut
+    // double dist = sqrt( pow(particle->getVertex()[0],2) + pow(particle->getVertex()[1],2) );
+    // if (dist<100.) passIP = true;
+
     //else std::cout<<"----- mc has dist from IP > 100mm"<<std::endl;
     //if (dist<30.) passIP = true;
-    
-    double e = sqrt( pow(particle->getEndpoint()[0],2) + pow(particle->getEndpoint()[1],2) );
-    if (e==0. || e>40.) passEndPoint=true;
+
+    // //passEndpoint Cut
+    // double e = sqrt( pow(particle->getEndpoint()[0],2) + pow(particle->getEndpoint()[1],2) );
+    // if (e==0. || e>40.) passEndPoint=true;
+
     //else std::cout<<"----- mc has endpoint < 40mm"<<std::endl;
     
     

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -225,9 +225,9 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 	cellid_decoder.setValue( id ) ;
 	streamlog_out(DEBUG1) << "id = " << id << std::endl;
 
-	int layer = cellid_decoder["layer"].value();
-	int subdet = cellid_decoder["system"].value();
-	int side = cellid_decoder["side"].value();
+	int layer = cellid_decoder[lcio::LCTrackerCellID::layer()].value();
+	int subdet = cellid_decoder[lcio::LCTrackerCellID::subdet()].value();
+	int side = cellid_decoder[lcio::LCTrackerCellID::side()].value();
 	streamlog_out(DEBUG1) << "layer = " << layer << std::endl;
 	streamlog_out(DEBUG1) << "subdet = " << subdet << std::endl;
 	streamlog_out(DEBUG1) << "side = " << side << std::endl;

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -300,6 +300,7 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 
       }//end loop on hits
 
+      delete marlin_trk;
 
     }//end loop on tracks
   }

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -124,7 +124,8 @@ void HitResiduals::init() {
 
   //tree
 
-  _out = new TFile(_outFileName.c_str(),"RECREATE");
+  AIDAProcessor::histogramFactory(this);
+
   _tree = new TTree(_treeName.c_str(),_treeName.c_str());
   int bufsize = 32000; //default buffer size 32KB
 
@@ -180,14 +181,6 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 
 
   streamlog_out(DEBUG2) << "----- _nEvt = " << _nEvt << std::endl;
-
-  //clear vectors
-  _resU.clear();
-  _resV.clear();
-  _subdet.clear();
-  _layer.clear();
-  _side.clear();
-
 
   UTIL::BitField64 cellid_decoder( lcio::LCTrackerCellID::encoding_string() ) ; 	    
   UTIL::BitField64 encoder( lcio::LCTrackerCellID::encoding_string() ) ; 	    
@@ -314,6 +307,12 @@ void HitResiduals::processEvent( LCEvent * evt ) {
 
   _tree->Fill();
 
+  //clear vectors
+  _resU.clear();
+  _resV.clear();
+  _subdet.clear();
+  _layer.clear();
+  _side.clear();
 
   streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber() 
 		       << "   in run:  " << evt->getRunNumber() << std::endl ;
@@ -334,9 +333,6 @@ void HitResiduals::check( LCEvent * ) {
 void HitResiduals::end(){ 
 
   _tree->Write();
-  _out->Write();
-  _out->Close();
-
   std::cout << "HitResiduals::end()  " << name() 
     	    << " processed " << _nEvt << " events in " << _nRun << " runs "
     	    << std::endl ;

--- a/Tracking/src/TrackChecker.cc
+++ b/Tracking/src/TrackChecker.cc
@@ -367,6 +367,10 @@ void TrackChecker::end(){
   //  if (!m_useOnlyTree) {
 
 
+  TF1 gaus = TF1("fitgaus", [](double* x, double* p){ return p[0]*TMath::Gaus(x[0], p[1], p[2], false);},-10, 10, 3);
+  gaus.SetParameter(0, 10);
+  gaus.SetParameter(1, 0);
+  gaus.SetParameter(2, 1);
 
     m_omegaPull->Write();
     m_phiPull->Write();
@@ -378,24 +382,24 @@ void TrackChecker::end(){
     pulls->Divide(3,2);
     pulls->cd(1);
     m_omegaPull->Draw();
-    m_omegaPull->Fit("gaus","");
     gStyle->SetOptFit(1111);
+    m_omegaPull->Fit(&gaus,"");
     pulls->cd(2);
     m_phiPull->Draw();
-    m_phiPull->Fit("gaus","");
     gStyle->SetOptFit(1111);
+    m_phiPull->Fit(&gaus,"");
     pulls->cd(3);
     m_tanLambdaPull->Draw();
-    m_tanLambdaPull->Fit("gaus","");
     gStyle->SetOptFit(1111);
+    m_tanLambdaPull->Fit(&gaus,"");
     pulls->cd(4);
     m_d0Pull->Draw();
-    m_d0Pull->Fit("gaus","");
     gStyle->SetOptFit(1111);
+    m_d0Pull->Fit(&gaus,"");
     pulls->cd(5);
     m_z0Pull->Draw();
-    m_z0Pull->Fit("gaus","");
     gStyle->SetOptFit(1111);
+    m_z0Pull->Fit(&gaus,"");
     pulls->Write();
 
     res = new TCanvas("res","Residuals of the track parameters",800,800);

--- a/Tracking/src/TrackChecker.cc
+++ b/Tracking/src/TrackChecker.cc
@@ -4,15 +4,7 @@
 #include "DDRec/API/IDDecoder.h"
 
 #include <marlinutil/HelixClass.h>
-#include "MarlinTrk/MarlinTrkUtils.h"
 #include "MarlinTrk/HelixTrack.h"
-#include "MarlinTrk/HelixFit.h"
-#include "MarlinTrk/HelixFit.h"
-#include "MarlinTrk/IMarlinTrack.h"
-#include "MarlinTrk/Factory.h"
-#include "MarlinTrk/MarlinTrkDiagnostics.h"
-#include "MarlinTrk/IMarlinTrkSystem.h"
-
 
 #include <EVENT/LCCollection.h>
 #include <IMPL/LCCollectionVec.h>
@@ -22,24 +14,19 @@
 #include <EVENT/MCParticle.h>
 #include <IMPL/TrackImpl.h>
 
-#include <UTIL/CellIDEncoder.h>
-#include <UTIL/LCTrackerConf.h>
-#include <UTIL/BitSet32.h>
 #include <UTIL/LCRelationNavigator.h>
 
 #include <marlinutil/GeometryUtil.h>
 
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_randist.h>
-
-#include "marlin/ProcessorEventSeeder.h"
-#include "marlin/Global.h"
 #include "marlin/AIDAProcessor.h"
 
-#include "CLHEP/Vector/TwoVector.h"
-
-#include <AIDA/IAnalysisFactory.h>
-#include <AIDA/IHistogramFactory.h>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <TMath.h>
 
 #include <cmath>
 #include <algorithm>
@@ -47,11 +34,6 @@
 #include <iostream>
 #include <climits>
 #include <cfloat>
-#include "TH1F.h"
-#include "TCanvas.h"
-#include "TFile.h"
-#include "TStyle.h"
-#include "TTree.h"
 
 using namespace lcio ;
 using namespace marlin ;
@@ -114,9 +96,6 @@ void TrackChecker::init() {
   
   // Get the magnetic field
   m_magneticField = MarlinUtil::getBzAtOrigin();
-
-	// Register this process
-	Global::EVENTSEEDER->registerProcessor(this);
 
   // Initialise histograms
   AIDAProcessor::histogramFactory(this);


### PR DESCRIPTION

BEGINRELEASENOTES
- TrackChecker: 
  * use c++ function instead of string for TF1, reduced memory allocation by 50MB
  * cleanup included header files
  * move creation of histograms and tree to init, register with AIDAProcessor to create own folder

* HitResiduals:
  * cleanup; use AIDArocessor to store output
  * clean marlin_trk object
  * use numeric indices to acces subdet, side and layer

* ClicEfficiencyCalculator:
  * comment unused variables for selection cuts
  * static_cast --> dynamic cast
  * move clearing of tree variables to end of event
  * cleanup header files, drop registration with eventseeder
  * wrap relations in shared_ptr to clean them automatically

ENDRELEASENOTES