### PR TITLE
Fix problem with root files

### DIFF
--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -598,15 +598,6 @@ void ClicEfficiencyCalculator::end(){
   // Calculate efficiency results
   streamlog_out(MESSAGE)<<std::fixed<<std::setprecision(2)<<"Reconstructable particle efficiency: "<<100.*m_particles["reconstructed"]/m_particles["reconstructable"]<<" % ("<<std::setprecision(0)<<m_particles["reconstructed"]<<"/"<<m_particles["reconstructable"]<<")"<<std::endl;
   
-  // Write out the trees
-  if (m_fullOutput){
-    m_mctree->Write();
-    m_trackTree->Write();
-    m_purityTree->Write();
-  }
-  if(m_simpleOutput){
-    m_simplifiedTree->Write();
-  }
   
 }
 

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -332,7 +332,6 @@ void HitResiduals::check( LCEvent * ) {
 
 void HitResiduals::end(){ 
 
-  _tree->Write();
   std::cout << "HitResiduals::end()  " << name() 
     	    << " processed " << _nEvt << " events in " << _nRun << " runs "
     	    << std::endl ;

--- a/Tracking/src/TrackChecker.cc
+++ b/Tracking/src/TrackChecker.cc
@@ -366,17 +366,13 @@ void TrackChecker::end(){
 
   //  if (!m_useOnlyTree) {
 
+  AIDAProcessor::histogramFactory(this);
 
   TF1 gaus = TF1("fitgaus", [](double* x, double* p){ return p[0]*TMath::Gaus(x[0], p[1], p[2], false);},-10, 10, 3);
   gaus.SetParameter(0, 10);
   gaus.SetParameter(1, 0);
   gaus.SetParameter(2, 1);
 
-    m_omegaPull->Write();
-    m_phiPull->Write();
-    m_tanLambdaPull->Write();
-    m_d0Pull->Write();
-    m_z0Pull->Write();
  
     pulls = new TCanvas("pulls","Pulls of the track parameters",800,800);
     pulls->Divide(3,2);
@@ -415,23 +411,6 @@ void TrackChecker::end(){
     res->cd(5);
     m_z0Residual->Draw();
     res->Write();
-
-    m_omegaMCParticle->Write();
-    m_phiMCParticle->Write();
-    m_tanLambdaMCParticle->Write(); 
-    m_d0MCParticle->Write();
-    m_z0MCParticle->Write();
-  
-    m_omegaTrack->Write();
-    m_phiTrack->Write();
-    m_tanLambdaTrack->Write();
-    m_d0Track->Write();
-    m_z0Track->Write();
-  
-    m_trackChi2->Write();
-    //  }
-
-  perftree->Write();
 
 }
 

--- a/Tracking/src/TrackChecker.cc
+++ b/Tracking/src/TrackChecker.cc
@@ -368,10 +368,18 @@ void TrackChecker::end(){
 
   AIDAProcessor::histogramFactory(this);
 
-  TF1 gaus = TF1("fitgaus", [](double* x, double* p){ return p[0]*TMath::Gaus(x[0], p[1], p[2], false);},-10, 10, 3);
+  TF1 gaus = TF1("fitgaus", [](double* x, double* p){ return p[0]*TMath::Gaus(x[0], p[1], p[2], true);},-10, 10, 3);
   gaus.SetParameter(0, 10);
   gaus.SetParameter(1, 0);
   gaus.SetParameter(2, 1);
+
+  gaus.SetParError(0, 1);
+  gaus.SetParError(1, 0.1);
+  gaus.SetParError(2, 0.1);
+
+  gaus.SetParName(0, "N");
+  gaus.SetParName(1, "#mu");
+  gaus.SetParName(2, "#sigma");
 
  
     pulls = new TCanvas("pulls","Pulls of the track parameters",800,800);


### PR DESCRIPTION

BEGINRELEASENOTES
- Ensure that histograms and trees are written only to their folder in the RootFile. AIDAProcessor already writes the outputs so we don't have to as well
- TrackChecker: beautify fit output by naming parameters. Fix issue with unnormalised gauss function

ENDRELEASENOTES