### PR TITLE
Reconstruction: Add Output_REC/DST processors

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-
-
 SET( test_name "test_CLIC_o2_v04_sim" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
@@ -12,7 +9,13 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o2_v04_reco_truth" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Tracking=Truth --global.MaxRecordNumber=3 --MyLCIOOutputProcessor.LCIOOutputFile=reco_truth.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml
+  --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml
+  --Config.Tracking=Truth
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_truth_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_truth_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -21,7 +24,13 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o2_v04_reco_conformal" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Tracking=Conformal --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_conformal.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml
+  --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml
+  --Config.Tracking=Conformal
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_conformal_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -29,7 +38,14 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o2_v04_reco_overlay" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml
+  --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml
+  --Config.Overlay=3TeV
+  --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_overlay_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -39,7 +55,18 @@ SET( test_name "test_CLIC_o2_v04_reco_conformal_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
-  ${VALGRIND} --leak-check=full --show-leak-kinds=all --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp Marlin --InitDD4hep.DD4hepXMLFile=CLIC_o2_v04/CLIC_o2_v04.xml --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio --global.MaxRecordNumber=10  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v04.slcio
+  ${VALGRIND}
+  --leak-check=full
+  --show-leak-kinds=all
+  --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp Marlin
+  --InitDD4hep.DD4hepXMLFile=CLIC_o2_v04/CLIC_o2_v04.xml
+  --global.LCIOInputFiles=testCLIC_o2_v04.slcio clicReconstruction_o2.xml
+  --Config.Overlay=3TeV
+  --Config.Tracking=Conformal
+  --Overlay3TeV.BackgroundFileNames=testCLIC_o2_v04.slcio
+  --global.MaxRecordNumber=10
+  --Output_REC.LCIOOutputFile=reco_overlay_truth_v04_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_truth_v04_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -50,7 +77,12 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_sim" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
-  ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --runType=batch -G -N=100 --outputFile=testCLIC_o3_v11.slcio --gun.isotrop=true --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
+  ddsim
+  --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --runType=batch -G -N=100
+  --outputFile=testCLIC_o3_v11.slcio
+  --gun.isotrop=true
+  --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
@@ -58,7 +90,13 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_truth" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Truth --global.MaxRecordNumber=3 --MyLCIOOutputProcessor.LCIOOutputFile=reco_truthl_v11.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  --Config.Tracking=Truth
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_truthl_v11_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_truthl_v11_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -67,7 +105,13 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_conformal" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Tracking=Conformal --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_conformal_v11.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  --Config.Tracking=Conformal
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_conformal_v11_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_v11_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -75,7 +119,14 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 SET( test_name "test_CLIC_o3_v11_reco_overlay" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
-  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_v11.slcio
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
+  --Config.Overlay=3TeV
+  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_overlay_v11_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_v11_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -84,13 +135,19 @@ SET( test_name "test_CLIC_o3_v11_reco_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
-  ${VALGRIND} --leak-check=full --show-leak-kinds=all
+  ${VALGRIND}
+  --leak-check=full
+  --show-leak-kinds=all
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
-  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
   --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
-  --Config.Overlay=3TeV --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
-  --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_v11.slcio
+  --Config.Overlay=3TeV
+  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_overlay_v11_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_v11_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
@@ -99,13 +156,20 @@ SET( test_name "test_CLIC_o3_v11_reco_conformal_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
-  ${VALGRIND} --leak-check=full --show-leak-kinds=all
+  ${VALGRIND}
+  --leak-check=full
+  --show-leak-kinds=all
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
-  Marlin --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
+  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v11/CLIC_o3_v11.xml
   --global.LCIOInputFiles=testCLIC_o3_v11.slcio clicReconstruction.xml
-  --Config.Overlay=3TeV --Config.Tracking=Conformal --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
-  --global.MaxRecordNumber=3  --MyLCIOOutputProcessor.LCIOOutputFile=reco_overlay_truth_v11.slcio
+  --Config.Overlay=3TeV
+  --Config.Tracking=Conformal
+  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v11.slcio
+  --global.MaxRecordNumber=3
+  --Output_REC.LCIOOutputFile=reco_overlay_truth_v11_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_truth_v11_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -44,7 +44,9 @@
     <!-- ========== output  ========== -->
 
     <group name="PfoSelector" />
-    <processor name="MyLCIOOutputProcessor"/>
+
+    <processor name="Output_REC"/>
+    <processor name="Output_DST"/>
 
   </execute>
 
@@ -249,17 +251,6 @@
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <parameter name="Verbosity" type="string">WARNING </parameter>
   </processor>
-
-
-  <processor name="MyLCIOOutputProcessor" type="LCIOOutputProcessor">
-    <!--   standard output: full reconstruction keep all collections -->
-    <parameter name="LCIOOutputFile" type="string"> sitracks.slcio </parameter>
-    <parameter name="FullSubsetCollections" type="StringVec"> EfficientMCParticles InefficientMCParticles </parameter>
-    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
-    <parameter name="Verbosity" type="string">WARNING </parameter>
-  </processor>
-
-
 
   <!-- == TruthTrackFinder parameters == -->
   <processor name="MyTruthTrackFinder" type="TruthTrackFinder">
@@ -1037,5 +1028,47 @@
     </processor>
 
   </group>
+
+  <processor name="Output_REC" type="LCIOOutputProcessor">
+    <!--   standard output: full reconstruction keep all collections -->
+    <parameter name="LCIOOutputFile" type="string"> Output_REC.slcio </parameter>
+    <parameter name="FullSubsetCollections" type="StringVec"> EfficientMCParticles InefficientMCParticles </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <parameter name="Verbosity" type="string">WARNING </parameter>
+  </processor>
+
+  <processor name="Output_DST" type="LCIOOutputProcessor">
+    <!--   dst output: keep only collections for analysis -->
+    <parameter name="LCIOOutputFile" type="string"> Output_DST.slcio </parameter>
+    <parameter name="FullSubsetCollections" type="StringVec">
+      EfficientMCParticles
+      InefficientMCParticles
+      MCParticlesSkimmed
+    </parameter>
+    <parameter name="DropCollectionTypes" type="StringVec">
+      MCParticle
+      LCRelation
+      SimCalorimeterHit
+      CalorimeterHit
+      SimTrackerHit
+      TrackerHit
+      TrackerHitPlane
+      Track
+      ReconstructedParticle
+      LCFloatVec
+    </parameter>
+    <parameter name="KeepCollectionNames" type="StringVec">
+      MCParticlesSkimmed
+      RecoMCTruthLink
+      SiTracks
+      PandoraClusters
+      PandoraPFOs
+      SelectedPandoraPFOs
+      LooseSelectedPandoraPFOs
+      TightSelectedPandoraPFOs
+    </parameter>
+    <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
+    <parameter name="Verbosity" type="string">WARNING </parameter>
+  </processor>
 
 </marlin>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -740,6 +740,12 @@
     <parameter name="D0TrackCut" type="float">50 </parameter>
     <!--d0 cut used to determine whether unmatched vertex track can form pfo-->
     <parameter name="D0UnmatchedVertexTrackCut" type="float">5 </parameter>
+
+    <!--The algorithm name for filling start vertex-->
+    <parameter name="StartVertexAlgorithmName" type="string">PandoraPFANew </parameter>
+    <!--Start Vertex Collection Name-->
+    <parameter name="StartVertexCollectionName" type="string" lcioOutType="Vertex"> PandoraStartVertices </parameter>
+
   </processor>
 
   <processor name="MyDDSimpleMuonDigi" type="DDSimpleMuonDigi">
@@ -958,7 +964,7 @@
     <!--PtCutForTightTiming-->
     <parameter name="PtCutForTightTiming" type="float">0.75 </parameter>
     <!--Selected pfo collection name-->
-    <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">SelectedPandoraPFANewPFOs </parameter>
+    <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">SelectedPandoraPFOs </parameter>
     <!--UseClusterLessPfos-->
     <parameter name="UseClusterLessPfos" type="int">1 </parameter>
     <!--UseNeutronTiming-->
@@ -967,7 +973,7 @@
     <parameter name="Verbosity" type="string">MESSAGE </parameter>
 
     <processor name="MyCLICPfoSelectorDefault" type="CLICPfoSelector">
-      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle"> SelectedPandoraPFANewPFOs </parameter>
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle"> SelectedPandoraPFOs </parameter>
     </processor>
 
     <processor name="MyCLICPfoSelectorLoose" type="CLICPfoSelector">
@@ -992,7 +998,7 @@
       <!--PhotonTightTimingCut-->
       <parameter name="PhotonTightTimingCut" type="float">2. </parameter>
       <!--Selected pfo collection name-->
-      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">LooseSelectedPandoraPFANewPFOs </parameter>
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">LooseSelectedPandoraPFOs </parameter>
       <parameter name="Monitoring" type="int">0</parameter>
     </processor>
 
@@ -1021,7 +1027,7 @@
       <!--PtCutForTightTiming-->
       <parameter name="PtCutForTightTiming" type="float">1.0 </parameter>
       <!--Selected pfo collection name-->
-      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">TightSelectedPandoraPFANewPFOs </parameter>
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">TightSelectedPandoraPFOs </parameter>
       <!--UseClusterLessPfos-->
       <parameter name="UseClusterLessPfos" type="int">0 </parameter>
       <parameter name="Monitoring" type="int">0</parameter>


### PR DESCRIPTION
For running via the production system I need the two output processors, and something in the file names with `_REC`  and `_DST`

BEGINRELEASENOTES
- Reconstruction: Add REC/DST OutputProcessors
- Reconstruction: Change default name of the output file to Output_REC.slcio and Output_DST.slcio instead of sitracks.slcio
- Reconstruction: Change name of `SelectedPandoraPFO` collections. Instead of `SelectedPandoraPFANewPFO` collections

ENDRELEASENOTES