### PR TITLE
updated chi2 for conformal tracking and removed tracker hit collectio…

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -269,17 +269,17 @@
     <!--ConformalTracking constructs tracks using a combined conformal mapping and cellular automaton approach.-->
 
     <!--Name of the TrackerHit input collections-->
-    <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDTrackerHits VXDEndcapTrackerHits ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits  </parameter>
+    <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDTrackerHits VXDEndcapTrackerHits </parameter>
     <!--Name of the TrackerHit relation collections-->
-    <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation">VXDTrackerHitRelations VXDEndcapTrackerHitRelations InnerTrackerBarrelHitsRelations OuterTrackerBarrelHitsRelations InnerTrackerEndcapHitsRelations OuterTrackerEndcapHitsRelations  </parameter>
+    <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation">VXDTrackerHitRelations VXDEndcapTrackerHitRelations </parameter>
 
     <!--Cut values for the pattern recognition -->
     <parameter name="ThetaRange" type="double"> 0.03 </parameter>
     <parameter name="MaxCellAngle" type="double"> 0.005 </parameter>
     <parameter name="MaxCellAngleRZ" type="double"> 0.005 </parameter>
     <parameter name="MaxDistance" type="double"> 0.02 </parameter>
-    <parameter name="MinClustersOnTrack" type="int"> 4 </parameter>
-    <parameter name="MaxChi2" type="double"> 10 </parameter>
+    <parameter name="MinClustersOnTrack" type="int"> 6 </parameter>
+    <parameter name="MaxChi2" type="double"> 50 </parameter>
     <parameter name="DebugPlots" type="bool"> false </parameter>
     <parameter name="trackPurity" type="double">0.7 </parameter>
 


### PR DESCRIPTION
…ns. If included, the conformal tracking will extend tracks through them and the extrapolator should not be used. Still under testing



BEGINRELEASENOTES
- updated chi2 for conformal tracking to account for new track fit
- removed tracker hit collections from steering file. If included, the conformal tracking will extend tracks through them and the extrapolator should not be used. Still under testing
ENDRELEASENOTES