### PR TITLE
Fixes for hit residuals, reconstruction

### DIFF
--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -393,7 +393,7 @@ int HitResiduals::FitInit2( Track*& track, MarlinTrk::IMarlinTrack*& _marlinTrk 
 
 int HitResiduals::FitInitFromLCIOTrackState( Track*& track, MarlinTrk::IMarlinTrack*& _marlinTrk ){
 
-  const auto* trackState = track->getTrackState(TrackState::AtFirstHit);
+  const auto* trackState = track->getTrackState(TrackState::AtIP);
 
   if( not trackState ) {
     return IMarlinTrack::error;

--- a/Tracking/src/HitResiduals.cc
+++ b/Tracking/src/HitResiduals.cc
@@ -207,7 +207,11 @@ void HitResiduals::processEvent( LCEvent * evt ) {
       	marlin_trk->addHit(*it);	
       }//end loop on hits
       //int init_status = FitInit2(track, marlin_trk);          
-      /* int init_status = */ FitInitFromLCIOTrackState(track, marlin_trk);
+      int init_status = FitInitFromLCIOTrackState(track, marlin_trk);
+      if( init_status != IMarlinTrack::success ) {
+        streamlog_out( WARNING ) << "Failed to initialise from trackstate, Skipping this track" << std::endl;
+        continue;
+      }
       //int fit_status = marlin_trk->fit(); 
       //streamlog_out(DEBUG2) << "fit status (good = 0) = " << fit_status << std::endl;
 
@@ -388,11 +392,14 @@ int HitResiduals::FitInit2( Track*& track, MarlinTrk::IMarlinTrack*& _marlinTrk 
 
 
 int HitResiduals::FitInitFromLCIOTrackState( Track*& track, MarlinTrk::IMarlinTrack*& _marlinTrk ){
-  
-  
-  TrackStateImpl trackState( *(track->getTrackState(TrackState::AtFirstHit)) );  
 
-  _marlinTrk->initialise( trackState, _bField, IMarlinTrack::forward ) ;
+  const auto* trackState = track->getTrackState(TrackState::AtFirstHit);
+
+  if( not trackState ) {
+    return IMarlinTrack::error;
+  }
+
+  _marlinTrk->initialise( *trackState, _bField, IMarlinTrack::forward ) ;
 
   // TrackStateImpl trackState( *(track->getTrackState(TrackState::AtLastHit)) );
 

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -419,7 +419,7 @@
     <!--maximum allowable chi2 increment when moving from one site to another-->
     <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
     <!--Use MultipleScattering in Fit-->
-    <parameter name="MultipleScatteringOn" type="bool">jtrue </parameter>
+    <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
     <!--Refit Track to MCParticle relation collection Name-->
     <parameter name="OutputRelationCollectionName" type="string" lcioOutType="LCRelation">
       SiTracks_Refitted_Relation

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -528,7 +528,7 @@
     <!--Name of the efficiency tree-->
     <parameter name="mcTreeName" type="string">mctree </parameter>   <!-- probably to be killed soon -->
     <!--Track collection name-->
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track">SiTracks </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
     <!--Name of the TrackerHit input collections-->
     <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane"> VXDTrackerHits VXDEndcapTrackerHits ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits  </parameter>
     <!--Name of TrackerHit relation collections-->
@@ -985,7 +985,7 @@
     <!--Smooth All Mesurement Sites in Fit-->
     <parameter name="SmoothOn" type="bool">false </parameter>
     <!--Name of the input track collection-->
-    <parameter name="TrackCollectionName" type="string" lcioInType="Track">SiTracks </parameter>
+    <parameter name="TrackCollectionName" type="string" lcioInType="Track"> SiTracks_Refitted </parameter>
     <!--Name of the output root file-->
     <parameter name="outFileName" type="string">residuals.root </parameter>
     <!--Name of the tree-->


### PR DESCRIPTION
BEGINRELEASENOTES
- HitResiduals: protect against missing trackstate
- HitResiduals: use AtIP instead of AtFirstHit
- Reconstruction: fix typo in parameter value for RefitFinal (inconsequential as using default value anyway)
- Reconstruction: use SiTracks_Refitted for HitResiduals and CLICEfficiencyCalculator

ENDRELEASENOTES