### PR TITLE
ClicEfficiencyCalculator: Removed purity selection on reconstructed t…

### DIFF
--- a/Tracking/include/ClicEfficiencyCalculator.h
+++ b/Tracking/include/ClicEfficiencyCalculator.h
@@ -92,7 +92,6 @@ protected:
   // Parameters
   bool m_fullOutput = false;
   bool m_simpleOutput = false;
-  double m_purity = 0.0;
   double m_magneticField = 0.0;
   std::string m_cuts = "";
   std::string m_mcTreeName = "";
@@ -142,7 +141,7 @@ protected:
   std::vector<double > m_vec_p = {};
   
   TTree *m_simplifiedTree = NULL;
-  double m_type = 0.0, m_pt = 0.0, m_theta = 0.0, m_phi = 0.0, m_vertexR = 0.0, m_closeTracks = 0.0;
+  double m_type = 0.0, m_pt = 0.0, m_theta = 0.0, m_phi = 0.0, m_vertexR = 0.0, m_closeTracks = 0.0, m_purity = 0.0;
   int m_nHits = 0, m_nHitsMC = 0;
   bool m_reconstructed = false;
 

--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -93,12 +93,6 @@ ClicEfficiencyCalculator::ClicEfficiencyCalculator() : Processor("ClicEfficiency
                              m_cuts,
                              std::string("NHits"));
   
-  // Flag for acceptable purity level
-  registerProcessorParameter( "trackPurity",
-                             "Purity level used to accept good tracks",
-                             m_purity,
-                             double(0.75));
-  
   // Flag for ntuples to be written
   registerProcessorParameter( "debugPlots",
                              "If true additional plots (n of hits per subdetector per mc particle, mc theta, mc pt, info if the particle is decayed in the tracker) will be added to the Ntuple mctree",
@@ -215,6 +209,7 @@ void ClicEfficiencyCalculator::init() {
     m_simplifiedTree->Branch("m_reconstructed", &m_reconstructed, "m_reconstructed/O");
     m_simplifiedTree->Branch("m_nHits", &m_nHits, "m_nHits/I");
     m_simplifiedTree->Branch("m_nHitsMC", &m_nHitsMC, "m_nHitsMC/I");
+    m_simplifiedTree->Branch("m_purity",&m_purity,"m_purity/D");
     m_simplifiedTree->Branch("m_eventNumber", &m_eventNumber, "m_eventNumber/I");
   }
   
@@ -355,6 +350,10 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     }
     double purity = (double)maxHits/(double)(nHits-nExcluded);
     
+    if(m_simpleOutput){
+      m_purity = purity;
+    }
+
     // Save additional information
     if(m_fullOutput){
       
@@ -381,9 +380,6 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
         m_vec_pdg.push_back(fabs(associatedParticle->getPDG()));
       }
     }
-    
-    // Now compare the purity
-    if(purity < m_purity) continue; // do something with ghosts here
     
     // Now have a track which is associated to a particle
     particleTracks[associatedParticle]++;


### PR DESCRIPTION
…racks to compute efficiency and added purity info in simplifiedEfficiencyTree



BEGINRELEASENOTES
- Removed purity selection on reconstructed tracks to compute efficiency. This makes tracking efficiency independent on purity.
- Added purity info in simplifiedEfficiencyTree: can be used to cut offline on the purity. 
ENDRELEASENOTES