### PR TITLE
ClicEfficiencyCalculator: added 'isSignal' flag for MCPhysicsParticles

### DIFF
--- a/Tracking/include/ClicEfficiencyCalculator.h
+++ b/Tracking/include/ClicEfficiencyCalculator.h
@@ -77,6 +77,7 @@ protected:
   std::vector<std::string> m_inputTrackerHitCollections = {};
   std::vector<std::string> m_inputTrackerHitRelationCollections = {};
   std::string m_inputParticleCollection = "";
+  std::string m_inputPhysicsParticleCollection = "";
   std::string m_inputTrackCollection = "";
   std::string m_inputTrackRelationCollection = "";
   std::string m_outputEfficientMCParticleCollection = "";
@@ -143,7 +144,7 @@ protected:
   TTree *m_simplifiedTree = NULL;
   double m_type = 0.0, m_pt = 0.0, m_theta = 0.0, m_phi = 0.0, m_vertexR = 0.0, m_distClosestMCPart = 0.0,  m_closeTracks = 0.0, m_purity = 0.0;
   int m_nHits = 0, m_nHitsMC = 0;
-  bool m_reconstructed = false;
+  bool m_reconstructed = false, m_signal = false;
 
 
 } ;

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -535,6 +535,8 @@
     <parameter name="TrackerHitRelCollectionNames" type="StringVec" lcioInType="LCRelation"> VXDTrackerHitRelations VXDEndcapTrackerHitRelations InnerTrackerBarrelHitsRelations OuterTrackerBarrelHitsRelations InnerTrackerEndcapHitsRelations OuterTrackerEndcapHitsRelations </parameter>
     <!--Name of the MCParticle input collection-->
     <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <!--Name of the MCPhysicsParticles input collection-->
+    <parameter name="MCPhysicsParticleCollectionName" type="string" lcioInType="MCParticle">MCPhysicsParticles </parameter>
     <!--Name of the output collection of the not reconstructed charged MCParticle-->
     <parameter name="MCParticleNotReco" type="string" lcioOutType="MCParticle">MCParticleNotReco </parameter>
     <!--If true additional plots (n of hits per subdetector per mc particle, mc theta, mc pt, info if the particle is decayed in the tracker) will be added to the Ntuple mctree-->


### PR DESCRIPTION

BEGINRELEASENOTES
- ClicEfficiencyCalculator: added 'isSignal' flag for MCPhysicsParticles
- MCPhysicsParticles collection is the output of the Overlay Processor
- in case of no overlay, the MCParticle collection is used instead
- clicReconstruction.xml: MCPhysicsParticles collection as input
ENDRELEASENOTES