### PR TITLE
CLIC Reconstruction: dstOutput, tests, pfo selector

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -336,3 +336,50 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   REQUIRED_FILES "/eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_37.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_38.slcio"
   TIMEOUT 300000
   )
+
+
+SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_profile" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND
+  ${CMAKE_SOURCE_DIR}/Tests/bin/Profiler.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so
+  amplxe-cl -collect hotspots -r ../ClicReco/r@@@{at}
+  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
+  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --Config.Tracking=Conformal
+  --global.MaxRecordNumber=10
+  --Output_REC.LCIOOutputFile=reco_conformal_v13_zuds_rec_prof.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_v13_zuds_dst_prof.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  CONFIGURATIONS PROF
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
+  FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
+  DEPENDS test_CLIC_o3_v13_sim_zuds
+  TIMEOUT 300000
+  )
+
+
+SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_overlay_profile" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND
+  ${CMAKE_SOURCE_DIR}/Tests/bin/Profiler.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so
+  amplxe-cl -collect hotspots -r ../ClicReco/r@@@{at}_over
+  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
+  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --Config.Overlay=3TeV
+  --Config.Tracking=Conformal
+  --Overlay3TeV.BackgroundFileNames="gghad_sim_8494_37.slcio gghad_sim_8494_38.slcio"
+  --global.MaxRecordNumber=1
+  --Output_REC.LCIOOutputFile=reco_overlay_conformal_v13_zuds_rec_over_prof.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_conformal_v13_zuds_dst_over_prof.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  CONFIGURATIONS PROF
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
+  FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
+  DEPENDS test_CLIC_o3_v13_sim_zuds
+  REQUIRED_FILES "gghad_sim_8494_37.slcio;gghad_sim_8494_38.slcio"
+  TIMEOUT 300000
+  )

--- a/Tests/bin/Profiler.sh
+++ b/Tests/bin/Profiler.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Simple script to run marlin tests with profiler on top
+#   calls the command (given as second argument)
+#   with all following arguments
+
+#----- initialize profiler environment
+source /cvmfs/projects.cern.ch/intelsw/psxe/linux/all-setup.sh
+#----- parse command line - first argument is the
+#      test to run
+## Drop existing ClicPerformance from MARLIN_DLL
+MARLIN_DLL=`echo $MARLIN_DLL | sed -e 's/:\?[-a-z0-9A-Z_/.]*libClicPerformance.so[.0-9]*:\?/:/'`
+export MARLIN_DLL=$1:$MARLIN_DLL
+command=$2
+theargs=""
+
+##Drop two
+shift
+shift
+for i in "$@" ; do
+    theargs="${theargs} $i"
+done
+
+echo " #### MARLIN_DLL = :  ${MARLIN_DLL}"
+
+echo " ### running test :  '${command} ${theargs}'"
+exec ${command} ${theargs}

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -1113,11 +1113,11 @@
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <parameter name="Verbosity" type="string">MESSAGE </parameter>
 
-    <processor name="MyCLICPfoSelectorDefault" type="CLICPfoSelector">
+    <processor name="CLICPfoSelectorDefault_HE" type="CLICPfoSelector">
       <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle"> SelectedPandoraPFOs </parameter>
     </processor>
 
-    <processor name="MyCLICPfoSelectorLoose" type="CLICPfoSelector">
+    <processor name="CLICPfoSelectorLoose_HE" type="CLICPfoSelector">
       <!--Selects Pfos from full PFO list using timing cuts-->
       <!--ChargedPfoNegativeLooseTimingCut-->
       <parameter name="ChargedPfoNegativeLooseTimingCut" type="float">-2.0</parameter>
@@ -1143,7 +1143,7 @@
       <parameter name="Monitoring" type="int">0</parameter>
     </processor>
 
-    <processor name="MyCLICPfoSelectorTight" type="CLICPfoSelector">
+    <processor name="CLICPfoSelectorTight_HE" type="CLICPfoSelector">
       <!--Selects Pfos from full PFO list using timing cuts-->
       <!--ChargedPfoLooseTimingCut-->
       <parameter name="ChargedPfoLooseTimingCut" type="float">2.0 </parameter>
@@ -1172,6 +1172,97 @@
       <!--UseClusterLessPfos-->
       <parameter name="UseClusterLessPfos" type="int">0 </parameter>
       <parameter name="Monitoring" type="int">0</parameter>
+    </processor>
+
+    <processor name="CLICPfoSelectorDefault_LE" type="CLICPfoSelector">
+      <!--Selects Pfos from full PFO list using timing cuts-->
+      <!--Selected pfo collection name-->
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">
+        LE_SelectedPandoraPFOs
+      </parameter>
+      <!-- <parameter name="ChargedPfoPtCutForTightTiming" type="float">1.0</parameter> -->
+      <!-- <parameter name="NeutralHadronPtCutForTightTiming" type="float">1.0</parameter> -->
+      <!-- <parameter name="PhotonPtCutForTightTiming" type="float">1.0</parameter> -->
+      <parameter name="NeutralHadronPtCut" type="float">0.0</parameter>
+      <parameter name="NeutralHadronPtCutForLooseTiming" type="float">2.0</parameter>
+      <parameter name="NeutralHadronLooseTimingCut" type="float">5.0</parameter>
+      <parameter name="NeutralHadronTightTimingCut" type="float">2.5</parameter>
+      <parameter name="PhotonPtCut" type="float">0.0</parameter>
+      <parameter name="PhotonPtCutForLooseTiming" type="float">2.0</parameter>
+      <parameter name="PhotonLooseTimingCut" type="float">5.0</parameter>
+      <parameter name="PhotonTightTimingCut" type="float">1.0</parameter>
+      <parameter name="ChargedPfoPtCut" type="float">0.0</parameter>
+      <parameter name="ChargedPfoPtCutForLooseTiming" type="float">4.0</parameter>
+      <parameter name="ChargedPfoLooseTimingCut" type="float">10.0</parameter>
+      <parameter name="ChargedPfoTightTimingCut" type="float">3.0</parameter>
+      <parameter name="ChargedPfoNegativeLooseTimingCut" type="float">-5.0</parameter>
+      <parameter name="ChargedPfoNegativeTightTimingCut" type="float">-2.0</parameter>
+      <parameter name="ClusterLessPfoTrackTimeCut" type="float">10.</parameter>
+      <parameter name="MinMomentumForClusterLessPfos" type="float">0.0 </parameter>
+      <parameter name="MaxMomentumForClusterLessPfos" type="float">5.0 </parameter>
+      <parameter name="MinPtForClusterLessPfos" type="float">0.0 </parameter>
+      <parameter name="NeutralFarForwardLooseTimingCut" type="float">4.0 </parameter>
+      <parameter name="NeutralFarForwardTightTimingCut" type="float">2.0 </parameter>
+    </processor>
+
+    <processor name="CLICPfoSelectorLoose_LE" type="CLICPfoSelector">
+      <!--Selects Pfos from full PFO list using timing cuts-->
+      <!--Input PFO Collection-->
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">
+        LE_LooseSelectedPandoraPFOs
+      </parameter>
+      <parameter name="NeutralHadronPtCut" type="float">0.0</parameter>
+      <!-- <parameter name="NeutralHadronPtCutForTightTiming" type="float">0.75</parameter> -->
+      <!-- <parameter name="PhotonPtCutForTightTiming" type="float">0.75</parameter> -->
+      <!-- <parameter name="ChargedPfoPtCutForTightTiming" type="float">1.0</parameter> -->
+      <parameter name="NeutralHadronPtCutForLooseTiming" type="float">2.0</parameter>
+      <parameter name="NeutralHadronLooseTimingCut" type="float">10.0</parameter>
+      <parameter name="NeutralHadronTightTimingCut" type="float">5.0</parameter>
+      <parameter name="PhotonPtCut" type="float">0.0</parameter>
+      <parameter name="PhotonPtCutForLooseTiming" type="float">2.0</parameter>
+      <parameter name="PhotonLooseTimingCut" type="float">10.0</parameter>
+      <parameter name="PhotonTightTimingCut" type="float">2.5</parameter>
+      <parameter name="ChargedPfoPtCut" type="float">0.0</parameter>
+      <parameter name="ChargedPfoPtCutForLooseTiming" type="float">4.0</parameter>
+      <parameter name="ChargedPfoLooseTimingCut" type="float">10.0</parameter>
+      <parameter name="ChargedPfoTightTimingCut" type="float">5.0</parameter>
+      <parameter name="ChargedPfoNegativeLooseTimingCut" type="float">-20.0</parameter>
+      <parameter name="ChargedPfoNegativeTightTimingCut" type="float">-20.0</parameter>
+      <parameter name="ClusterLessPfoTrackTimeCut" type="float">50.</parameter>
+      <parameter name="MinMomentumForClusterLessPfos" type="float">0.0 </parameter>
+      <parameter name="MaxMomentumForClusterLessPfos" type="float">5.0 </parameter>
+      <parameter name="MinPtForClusterLessPfos" type="float">0.0 </parameter>
+      <parameter name="NeutralFarForwardLooseTimingCut" type="float">10.0 </parameter>
+      <parameter name="NeutralFarForwardTightTimingCut" type="float">5.0 </parameter>
+    </processor>
+
+    <processor name="CLICPfoSelectorTight_LE" type="CLICPfoSelector">
+      <!--Selects Pfos from full PFO list using timing cuts-->
+      <!--Input PFO Collection-->
+      <parameter name="SelectedPfoCollection" type="string" lcioOutType="ReconstructedParticle">LE_TightSelectedPandorPFOs </parameter>
+      <parameter name = "NeutralHadronPtCut" type="float">0.0</parameter>
+      <!-- <parameter name = "NeutralHadronPtCutForTightTiming" type="float">1.0</parameter> -->
+      <!-- <parameter name = "PhotonPtCutForTightTiming" type="float">1.0</parameter> -->
+      <!-- <parameter name = "ChargedPfoPtCutForTightTiming" type="float">1.5</parameter> -->
+      <parameter name="NeutralHadronPtCutForLooseTiming" type="float">3.0</parameter>
+      <parameter name="NeutralHadronLooseTimingCut" type="float">4.0</parameter>
+      <parameter name="NeutralHadronTightTimingCut" type="float">2.0</parameter>
+      <parameter name="PhotonPtCut" type="float">0.0</parameter>
+      <parameter name="PhotonPtCutForLooseTiming" type="float">2.0</parameter>
+      <parameter name="PhotonLooseTimingCut" type="float">1.0</parameter>
+      <parameter name="PhotonTightTimingCut" type="float">1.0</parameter>
+      <parameter name="ChargedPfoPtCut" type="float">0.0</parameter>
+      <parameter name="ChargedPfoPtCutForLooseTiming" type="float">3.0</parameter>
+      <parameter name="ChargedPfoLooseTimingCut" type="float">4.0</parameter>
+      <parameter name="ChargedPfoTightTimingCut" type="float">2.0</parameter>
+      <parameter name="ChargedPfoNegativeLooseTimingCut" type="float">-2.0</parameter>
+      <parameter name="ChargedPfoNegativeTightTimingCut" type="float">-1.0</parameter>
+      <parameter name="ClusterLessPfoTrackTimeCut" type="float">10.</parameter>
+      <parameter name="MinMomentumForClusterLessPfos" type="float">0.0 </parameter>
+      <parameter name="MaxMomentumForClusterLessPfos" type="float">5.0 </parameter>
+      <parameter name="MinPtForClusterLessPfos" type="float">0.75 </parameter>
+      <parameter name="NeutralFarForwardLooseTimingCut" type="float">2.0 </parameter>
+      <parameter name="NeutralFarForwardTightTimingCut" type="float">2.0 </parameter>
     </processor>
 
   </group>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -1001,9 +1001,9 @@
     <!--Number of Event that should be printed to PDF File-->
     <parameter name="PrintThisEvent" type="int">-1 </parameter>
     <!--Name of the Reconstructed Cluster collection-->
-    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BCalClusters </parameter>
+    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BeamCalClusters </parameter>
     <!--Name of the Reconstructed Particle collection-->
-    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BCalRecoParticle </parameter>
+    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BeamCalRecoParticles </parameter>
     <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
     <parameter name="SigmaCut" type="double">1 </parameter>
     <!--Layer (inclusive) from which on we start looking for signal clusters-->
@@ -1213,6 +1213,10 @@
       SelectedPandoraPFOs
       LooseSelectedPandoraPFOs
       TightSelectedPandoraPFOs
+      LumiCalClusters
+      LumiCalRecoParticles
+      BeamCalClusters
+      BeamCalRecoParticles
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
     <parameter name="Verbosity" type="string">WARNING </parameter>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -400,6 +400,11 @@
     <parameter name="DebugPlots" type="bool"> false </parameter>
     <parameter name="trackPurity" type="double">0.7 </parameter>
 
+    <!--sort results from kdtree search-->
+    <parameter name="SortTreeResults" type="bool">true </parameter>
+    <!--retry with tightened parameters, when too many tracks are being created-->
+    <parameter name="RetryTooManyTracks" type="bool">false </parameter>
+
     <!--Silicon track Collection Name-->
     <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracks </parameter>
     <!--Name of the MCParticle input collection-->

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -1208,6 +1208,7 @@
       MCParticlesSkimmed
       RecoMCTruthLink
       SiTracks
+      SiTracks_Refitted
       PandoraClusters
       PandoraPFOs
       SelectedPandoraPFOs


### PR DESCRIPTION

BEGINRELEASENOTES
- CLIC Reconstruction:
  - Add SiTracks_Refitted to DST Output, add LumiCal and BeamCal Cluster and RecoParticle to DST Output
  - Note that BeamCalReconstruction output collections have changed names to be consistent with LumiCalOutput
  - Add new options to ConformalTracking (iLCSoft/ConformalTracking#28, iLCSoft/ConformalTracking#29)
  - add call for running vtune on reconstruction (only works in CERN intranet)
     `ctest  -C PROF -R t_test_CLIC_o3_v13_reco_conformal_zuds_overlay_profile -V`

ENDRELEASENOTES