### PR TITLE
Add configuration for different BeamCal Reco energies (380GeV)

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -38,14 +38,14 @@
 
     <!-- ========== tracking  ========== -->
     <!-- At the moment the name of the final track collection for the MyTruthTrackFinder and MyExtrToTracker processors is the same, so that users can use this example to run easily both the cheater track pattern recognition (still the default for many tasks) or the real one (under final tests) -->
-    <if condition="Config.TruthTracking">
+    <if condition="Config.TrackingTruth">
       <processor name="MyTruthTrackFinder"/>
     </if>
-    <if condition="Config.ConformalPlusExtrapolatorTracking">
+    <if condition="Config.TrackingConformalPlusExtrapolator">
       <processor name="MyConformalTracking"/>
       <processor name="MyExtrToTracker"/>
     </if>
-    <if condition="Config.ConformalTracking">
+    <if condition="Config.TrackingConformal">
       <processor name="MyConformalTrackingFull"/>
     </if>
 
@@ -97,10 +97,20 @@
   </processor>
 
   <processor name="Config" type="CLICRecoConfig" >
-    <!--Which option to use for overlay: False, 3TeV, 380GeV. Then use, e.g., Config.Overlay3TeV in the condition-->
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
+    <!--Which option to use for BeamCal: 3TeV, 380GeV. Then use, e.g., Config.BeamCal3TeV in the condition-->
+    <parameter name="BeamCal" type="string">3TeV </parameter>
+    <!--Possible values and conditions for option BeamCal-->
+    <parameter name="BeamCalChoices" type="StringVec">3TeV 380GeV  </parameter>
+    <!--Which option to use for Overlay: False, 350GeV, 380GeV, 420GeV, 500GeV, 1.4TeV, 3TeV. Then use, e.g., Config.OverlayFalse in the condition-->
     <parameter name="Overlay" type="string">False </parameter>
-    <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal-->
+    <!--Possible values and conditions for option Overlay-->
+    <parameter name="OverlayChoices" type="StringVec">False 350GeV 380GeV 420GeV 500GeV 1.4TeV 3TeV  </parameter>
+    <!--Which option to use for Tracking: Truth, ConformalPlusExtrapolator, Conformal. Then use, e.g., Config.TrackingTruth in the condition-->
     <parameter name="Tracking" type="string">Truth </parameter>
+    <!--Possible values and conditions for option Tracking-->
+    <parameter name="TrackingChoices" type="StringVec">Truth ConformalPlusExtrapolator Conformal  </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
   </processor>
 
   <group name="Overlay">

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+  <constants>
+    <!-- Chose which BeamCalReco processor to run 380GeV or 3TeV -->
+    <constant name="BCReco" value="3TeV" />
+  </constants>
   <execute>
 
     <!-- ========== setup  ========== -->
@@ -56,7 +60,14 @@
     <processor name="MyDDSimpleMuonDigi"/> 
     <processor name="MyDDMarlinPandora"/> 
     <processor name="LumiCalReco"/>
-    <processor name="BeamCalReco"/>
+    <!-- FIXME: When new Marlin in in more widespread use?? -->
+    <!-- <processor name="BeamCalReco${BCReco}"/> -->
+    <if condition="Config.BeamCal3TeV">
+      <processor name="BeamCalReco3TeV"/>
+    </if>
+    <if condition="Config.BeamCal380GeV">
+      <processor name="BeamCalReco380GeV"/>
+    </if>
 
     <!-- ========== monitoring  ========== -->
     <processor name="MyClicEfficiencyCalculator"/>
@@ -985,53 +996,80 @@
   </processor>
 
 
-  <processor name="BeamCalReco" type="BeamCalClusterReco">
-    <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
-    <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged]-->
-    <parameter name="BackgroundMethod" type="string">Gaussian </parameter>
-    <!--Name of BeamCal Collection-->
-    <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">BeamCalCollection </parameter>
-    <!--Flag to create the TEfficiency for fast tagging library-->
-    <parameter name="CreateEfficiencyFile" type="bool">false </parameter>
-    <!--Rings from which onwards the outside Thresholds are used-->
-    <parameter name="StartingRing" type="FloatVec">0.0 1.0 1.5 2.5 3.5  4.5 </parameter>
-    <!--Energy in a Cluster to consider it an electron-->
-    <parameter name="ETCluster" type="FloatVec">   5.0 4.0 3.0 2.0 2.0  1.0 </parameter>
-    <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
-    <parameter name="ETPad" type="FloatVec">       0.5 0.4 0.3 0.2 0.15 0.1 </parameter>
-    <!--The name of the rootFile which will contain the TEfficiency objects-->
-    <parameter name="EfficiencyFilename" type="string">TaggingEfficiency.root </parameter>
-    <!--Root Inputfile(s)-->
-    <parameter name="InputFileBackgrounds" type="StringVec">BeamCal_BackgroundPars_3TeV.root </parameter>
-    <!--Multiply deposit energy by this factor to account for sampling fraction-->
-    <parameter name="LinearCalibrationFactor" type="double">116.44 </parameter>
-    <!--MCParticle Collection Name, only needed and used to estimate efficiencies-->
-    <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
-    <!--Minimum number of pads in a single tower to be considered for signal-->
-    <parameter name="MinimumTowerSize" type="int">4 </parameter>
-    <!--How many layers are used for shower fitting-->
-    <parameter name="NShowerCountingLayers" type="int">3 </parameter>
-    <!--Number of Bunch Crossings of Background-->
-    <parameter name="NumberOfBX" type="int"> 40 </parameter>
-    <!--Number of Event that should be printed to PDF File-->
-    <parameter name="PrintThisEvent" type="int">-1 </parameter>
-    <!--Name of the Reconstructed Cluster collection-->
-    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BeamCalClusters </parameter>
-    <!--Name of the Reconstructed Particle collection-->
-    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BeamCalRecoParticles </parameter>
-    <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
-    <parameter name="SigmaCut" type="double">1 </parameter>
-    <!--Layer (inclusive) from which on we start looking for signal clusters-->
-    <parameter name="StartLookingInLayer" type="int">10 </parameter>
-    <!--Limit on square norm of tower energy chi2/ndf, where chi2 = (E_dep - E_bg)^2/sig^2. 			      Reasonable value for pregenerated bkg is 5., for parametrised is 2.-->
-    <parameter name="TowerChi2ndfLimit" type="double">5 </parameter>
-    <!--Use Chi2 selection criteria to detect high energy electron in the signal.-->
-    <parameter name="UseChi2Selection" type="bool">false </parameter>
-    <!--Use the cuts for the pads specified in ETPad. If false, the standard deviation of each pad times the SigmaCut Factor is used, the first entry in ETPad is used as a minimum energy to consider a pad at all-->
-    <parameter name="UseConstPadCuts" type="bool">true </parameter>
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
-  </processor>
+  <group name="BeamCalReco">
+      <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
+      <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged]-->
+      <parameter name="BackgroundMethod" type="string">Gaussian </parameter>
+      <!--Name of BeamCal Collection-->
+      <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">BeamCalCollection </parameter>
+      <!--Name of the Reconstructed Cluster collection-->
+      <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BeamCalClusters </parameter>
+      <!--Name of the Reconstructed Particle collection-->
+      <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BeamCalRecoParticles </parameter>
+      <!--MCParticle Collection Name, only needed and used to estimate efficiencies-->
+      <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+      <!--Multiply deposit energy by this factor to account for sampling fraction-->
+      <parameter name="LinearCalibrationFactor" type="double">116.44 </parameter>
+      <!--Number of Bunch Crossings of Background-->
+      <parameter name="NumberOfBX" type="int"> 40 </parameter>
+      <!--Flag to create the TEfficiency for fast tagging library-->
+      <parameter name="CreateEfficiencyFile" type="bool">false </parameter>
+      <!--The name of the rootFile which will contain the TEfficiency objects-->
+      <parameter name="EfficiencyFilename" type="string">TaggingEfficiency.root </parameter>
+      <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+      <parameter name="Verbosity" type="string">DEBUG </parameter>
+      <!--Number of Event that should be printed to PDF File-->
+      <parameter name="PrintThisEvent" type="int">-1 </parameter>
+
+    <processor name="BeamCalReco3TeV" type="BeamCalClusterReco">
+      <parameter name="InputFileBackgrounds" type="StringVec">BeamCal_BackgroundPars_3TeV.root </parameter>
+      <!--Rings from which onwards the outside Thresholds are used-->
+      <parameter name="StartingRing" type="FloatVec">0.0 1.0 1.5 2.5 3.5  4.5 </parameter>
+      <!--Energy in a Cluster to consider it an electron-->
+      <parameter name="ETCluster" type="FloatVec">   5.0 4.0 3.0 2.0 2.0  1.0 </parameter>
+      <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
+      <parameter name="ETPad" type="FloatVec">       0.5 0.4 0.3 0.2 0.15 0.1 </parameter>
+      <!--Layer (inclusive) from which on we start looking for signal clusters-->
+      <parameter name="StartLookingInLayer" type="int">10 </parameter>
+      <!--Use the cuts for the pads specified in ETPad. If false, the standard deviation of each pad times the SigmaCut Factor is used, the first entry in ETPad is used as a minimum energy to consider a pad at all-->
+      <parameter name="UseConstPadCuts" type="bool">true </parameter>
+      <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
+      <parameter name="SigmaCut" type="double">1 </parameter>
+      <!--Minimum number of pads in a single tower to be considered for signal-->
+      <parameter name="MinimumTowerSize" type="int">4 </parameter>
+      <!--How many layers are used for shower fitting-->
+      <parameter name="NShowerCountingLayers" type="int">3 </parameter>
+      <!--Limit on square norm of tower energy chi2/ndf, where chi2 = (E_dep - E_bg)^2/sig^2. Reasonable value for pregenerated bkg is 5., for parametrised is 2.-->
+      <parameter name="TowerChi2ndfLimit" type="double">5 </parameter>
+      <!--Use Chi2 selection criteria to detect high energy electron in the signal.-->
+      <parameter name="UseChi2Selection" type="bool">false </parameter>
+    </processor>
+
+    <processor name="BeamCalReco380GeV" type="BeamCalClusterReco">
+      <parameter name="InputFileBackgrounds" type="StringVec">BeamCal_BackgroundPars_380GeV.root </parameter>
+      <!--Rings from which onwards the outside Thresholds are used-->
+      <parameter name="StartingRing" type="FloatVec">0.0 </parameter>
+      <!--Energy in a Cluster to consider it an electron-->
+      <parameter name="ETCluster" type="FloatVec">   1.0 </parameter>
+      <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
+      <parameter name="ETPad" type="FloatVec">       0.01 </parameter>
+      <!--Layer (inclusive) from which on we start looking for signal clusters-->
+      <parameter name="StartLookingInLayer" type="int">2 </parameter>
+      <!--Use the cuts for the pads specified in ETPad. If false, the standard deviation of each pad times the SigmaCut Factor is used, the first entry in ETPad is used as a minimum energy to consider a pad at all-->
+      <parameter name="UseConstPadCuts" type="bool">false </parameter>
+      <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
+      <parameter name="SigmaCut" type="double">1 </parameter>
+      <!--Minimum number of pads in a single tower to be considered for signal-->
+      <parameter name="MinimumTowerSize" type="int">4 </parameter>
+      <!--How many layers are used for shower fitting-->
+      <parameter name="NShowerCountingLayers" type="int">3 </parameter>
+      <!--Limit on square norm of tower energy chi2/ndf, where chi2 = (E_dep - E_bg)^2/sig^2. Reasonable value for pregenerated bkg is 5., for parametrised is 2.-->
+      <parameter name="TowerChi2ndfLimit" type="double">5 </parameter>
+      <!--Use Chi2 selection criteria to detect high energy electron in the signal.-->
+      <parameter name="UseChi2Selection" type="bool">false </parameter>
+    </processor>
+
+  </group>
 
   <group name="PfoSelector">
     <!--Selects Pfos from full PFO list using timing cuts-->

--- a/source/Conditions/include/CLICRecoConfig.h
+++ b/source/Conditions/include/CLICRecoConfig.h
@@ -6,6 +6,8 @@
 
 class CLICRecoConfig : public marlin::Processor, public marlin::EventModifier {
 
+  using Choices = std::vector<std::string>;
+
 public:
 
   virtual marlin::Processor*  newProcessor() { return new CLICRecoConfig; }
@@ -33,18 +35,24 @@ public:
 
 protected:
 
-  // Parameters
-  const std::vector< std::string > m_trackingPossibleOptions{ "Truth", "ConformalPlusExtrapolator", "Conformal" };
-  std::string m_trackingOption="Truth";
+  std::map<std::string, bool> m_options{};
 
-  // Parameters
-  std::vector< std::string > m_overlayPossibleOptions{ "False", "350GeV", "380GeV", "420GeV", "500GeV", "1.4TeV", "3TeV" };
-  std::map<std::string, bool> m_overlay{};
+  // Tracking
+  const Choices m_trackingPossibleOptions{"Truth", "ConformalPlusExtrapolator", "Conformal"};
+  std::string m_trackingChoice="Truth";
+
+  // Overlay
+  const Choices m_overlayPossibleOptions{"False", "350GeV", "380GeV", "420GeV", "500GeV", "1.4TeV", "3TeV"};
   std::string m_overlayChoice="False";
 
-  bool m_truthTracking = true;
-  bool m_conformalTrackingPlusExtrapolator = false;
-  bool m_conformalTracking = false;
+  // BeamCal
+  const Choices m_beamcalPossibleOptions{"3TeV", "380GeV"};
+  std::string m_beamcalChoice="3TeV";
+
+  std::vector<std::tuple<std::string, std::string, Choices>> m_allOptions =
+    {{"Tracking", m_trackingChoice, m_trackingPossibleOptions},
+     {"BeamCal",  m_beamcalChoice, m_beamcalPossibleOptions},
+     {"Overlay",  m_overlayChoice, m_overlayPossibleOptions}};
 
 
 protected:


### PR DESCRIPTION

BEGINRELEASENOTES
- Refactoring Config Processor: allow extending options via parameters, easier to add new options
- Add 380GeV BeamCalBackground file based on 380GeV L*=6m (http://clic-beam-beam.web.cern.ch/clic-beam-beam/380gev_l6_bx8mm.html)
- Waiting for ilcsoft/Marlin#28 to be deployed to optimize selection of processors, which makes the Config processor obsolete and command line arguments would would be `--constant....` instead of `--Config...`

ENDRELEASENOTES