### PR TITLE
Steering files: updated single point resolutions in trackers

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -242,7 +242,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float">0.007 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  -->
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float">0.3 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  --> 
+    <parameter name="ResolutionV" type="float">0.09 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  --> 
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> InnerTrackerBarrelCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -261,7 +261,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.005 0.007 0.007 0.007 0.007 0.007 0.007</parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 0.005 0.3 0.3 0.3 0.3 0.3 0.3</parameter>
+    <parameter name="ResolutionV" type="float"> 0.005 0.09 0.09 0.09 0.09 0.09 0.09</parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> InnerTrackerEndcapCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -280,7 +280,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.007 0.007 0.007</parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 1.5 3.0 3.0 </parameter>
+    <parameter name="ResolutionV" type="float"> 0.09 0.09 0.09 </parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerBarrelCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -299,7 +299,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.007 0.007 0.007 0.007 0.007 </parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 3.0 3.0 3.0 3.0 3.0 </parameter>
+    <parameter name="ResolutionV" type="float"> 0.09 0.09 0.09 0.09 0.09 </parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerEndcapCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -221,7 +221,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float">0.007 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  -->
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float">0.3 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  --> 
+    <parameter name="ResolutionV" type="float">0.09 </parameter> <!-- when only one number is provided, the hits in all the layers wll be smeared with the same resolution => it works for both CLIC_o2_v04 with 2 layers and CLIC_o3_v5 with 3 layers  --> 
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> InnerTrackerBarrelCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -240,7 +240,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.005 0.007 0.007 0.007 0.007 0.007 0.007</parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 0.005 0.3 0.3 0.3 0.3 0.3 0.3</parameter>
+    <parameter name="ResolutionV" type="float"> 0.005 0.09 0.09 0.09 0.09 0.09 0.09</parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit"> InnerTrackerEndcapCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -259,7 +259,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.007 0.007 0.007</parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 1.5 3.0 3.0 </parameter>
+    <parameter name="ResolutionV" type="float"> 0.09 0.09 0.09 </parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerBarrelCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->
@@ -278,7 +278,7 @@
     <!--resolution in direction of u-->
     <parameter name="ResolutionU" type="float"> 0.007 0.007 0.007 0.007 0.007 </parameter>
     <!--resolution in direction of v-->
-    <parameter name="ResolutionV" type="float"> 3.0 3.0 3.0 3.0 3.0 </parameter>
+    <parameter name="ResolutionV" type="float"> 0.09 0.09 0.09 0.09 0.09 </parameter>
     <!--Name of the Input SimTrackerHit collection-->
     <parameter name="SimTrackHitCollectionName" type="string" lcioInType="SimTrackerHit">OuterTrackerEndcapCollection </parameter>
     <!--Name of TrackerHit SimTrackHit relation collection-->


### PR DESCRIPTION

BEGINRELEASENOTES
- Updated steering files clicReconstruction.xml and fccReconstruction.xml
- Single point resolutions in the tracker (inner and outer, barrel and endcap): 7um x 90um
- all layers except 1st inner tracker endcap: still 5um x 5um

ENDRELEASENOTES