### PR TITLE
Reconstruction update: LumiCal Reco, RecoMCTruthLinker

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -73,65 +73,87 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 
 
 
-
-SET( test_name "test_CLIC_o3_v13_sim" )
+SET(EOS_BACKGROUND_FILE /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v14/SIM/00009245/000/gghad_sim_9245_37.slcio)
+SET(CLIC_DETECTOR_MODEL CLIC_o3_v14)
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_sim" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
   ddsim
-  --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
+  --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
   --runType=batch -G -N=100
-  --outputFile=testCLIC_o3_v13.slcio
+  --outputFile=test${CLIC_DETECTOR_MODEL}.slcio
   --gun.isotrop=true
   --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
 
-SET( test_name "test_CLIC_o3_v13_reco_truth" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_truth" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
   ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Tracking=Truth
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_truth_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_truth_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_truth_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_truth_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
   ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_conformal_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
 
-SET( test_name "test_CLIC_o3_v13_reco_overlay" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_overlay" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
   ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
-  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v13.slcio
+  --Overlay3TeV.BackgroundFileNames=test${CLIC_DETECTOR_MODEL}.slcio
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_overlay_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
 
-SET( test_name "test_CLIC_o3_v13_reco_overlay_valgrind" )
+
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_real_overlay" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
+  --Config.Overlay=3TeV
+  --Overlay3TeV.BackgroundFileNames=${EOS_BACKGROUND_FILE}
+  --global.MaxRecordNumber=4
+  --Output_REC.LCIOOutputFile=reco_overlay_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_${CLIC_DETECTOR_MODEL}_dst.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  CONFIGURATIONS EOS
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
+  FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
+  REQUIRED_FILES ${EOS_BACKGROUND_FILE}
+)
+
+
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
@@ -141,18 +163,18 @@ ADD_TEST( NAME t_${test_name}
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
-  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v13.slcio
+  --Overlay3TeV.BackgroundFileNames=test${CLIC_DETECTOR_MODEL}.slcio
   --global.MaxRecordNumber=3
-  --Output_REC.LCIOOutputFile=reco_overlay_valgrind_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_valgrind_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_valgrind_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_valgrind_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_valgrind" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
@@ -162,12 +184,12 @@ ADD_TEST( NAME t_${test_name}
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=3
-  --Output_REC.LCIOOutputFile=reco_conformal_valgrind_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_valgrind_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_valgrind_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_valgrind_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
@@ -175,7 +197,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
   )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_overlay_valgrind" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_overlay_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
@@ -185,14 +207,14 @@ ADD_TEST( NAME t_${test_name}
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
   --Config.Tracking=Conformal
-  --Overlay3TeV.BackgroundFileNames=testCLIC_o3_v13.slcio
+  --Overlay3TeV.BackgroundFileNames=test${CLIC_DETECTOR_MODEL}.slcio
   --global.MaxRecordNumber=3
-  --Output_REC.LCIOOutputFile=reco_overlay_conformal_valgrind_v13_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_conformal_valgrind_v13_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_conformal_valgrind_${CLIC_DETECTOR_MODEL}_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_conformal_valgrind_${CLIC_DETECTOR_MODEL}_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
@@ -200,13 +222,13 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
   )
 
 
-SET( test_name "test_CLIC_o3_v13_sim_zuds" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_sim_zuds" )
 ADD_TEST( NAME t_${test_name}
   COMMAND "$ENV{lcgeo_DIR}/bin/run_test_lcgeo.sh"
   ddsim
-  --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
+  --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
   --runType=batch -N=4
-  --outputFile=testCLIC_o3_v13_zuds.slcio
+  --outputFile=test${CLIC_DETECTOR_MODEL}_zuds.slcio
   --inputFiles /eos/experiment/clicdp/grid/ilc/user/w/webermat/stdhep/Zuds3000/Zuds3000__01.stdhep
   --steeringFile=${CMAKE_SOURCE_DIR}/examples/clic_steer.py
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
@@ -218,27 +240,50 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   TIMEOUT 300000
   )
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
   ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_conformal_v13_zuds_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_v13_zuds_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   CONFIGURATIONS EOS
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
+  TIMEOUT 300000
+  )
+
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds_overlay" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_SOURCE_DIR}/Tests/bin/MarlinTests.sh
+  ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
+  --Config.Tracking=Conformal
+  --global.MaxRecordNumber=4
+  --Config.Overlay=3TeV
+  --Overlay3TeV.BackgroundFileNames=${EOS_BACKGROUND_FILE}
+  --Output_REC.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
+  CONFIGURATIONS EOS
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
+  FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
+  REQUIRED_FILES "${EOS_BACKGROUND_FILE}"
   TIMEOUT 300000
   )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_valgrind" )
+
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
@@ -248,21 +293,21 @@ ADD_TEST( NAME t_${test_name}
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_conformal_valgrind_v13_zuds_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_valgrind_v13_zuds_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_valgrind_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_valgrind_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
   TIMEOUT 300000
   )
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_overlay_zuds_valgrind" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_overlay_zuds_valgrind" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
@@ -272,114 +317,114 @@ ADD_TEST( NAME t_${test_name}
   --suppressions=${ROOT_DIR}/../etc/valgrind-root.supp
   --suppressions=${CMAKE_SOURCE_DIR}/etc/extra-root.supp
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
   --Config.Tracking=Conformal
-  --Overlay3TeV.BackgroundFileNames="/eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_37.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_38.slcio"
+  --Overlay3TeV.BackgroundFileNames=${EOS_BACKGROUND_FILE}
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_overlay_conformal_valgrind_v13_zuds_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_conformal_valgrind_v13_zuds_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_conformal_valgrind_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_conformal_valgrind_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
-  REQUIRED_FILES "/eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_37.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_38.slcio"
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
+  REQUIRED_FILES ${EOS_BACKGROUND_FILE}
   TIMEOUT 300000
   )
 
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_massif" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds_massif" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
   ${VALGRIND}
   --tool=massif
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_conformal_msassif_v13_zuds_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_msassif_v13_zuds_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_msassif_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_msassif_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
   TIMEOUT 300000
   )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_overlay_zuds_massif" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_overlay_zuds_massif" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/ValgrindTests.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so ${VALGRIND_LIB}
   ${VALGRIND}
   --tool=massif
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
   --Config.Tracking=Conformal
-  --Overlay3TeV.BackgroundFileNames="/eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_37.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_38.slcio"
+  --Overlay3TeV.BackgroundFileNames=${EOS_BACKGROUND_FILE}
   --global.MaxRecordNumber=4
-  --Output_REC.LCIOOutputFile=reco_overlay_conformal_v13_zuds_rec.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_conformal_v13_zuds_dst.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_conformal_${CLIC_DETECTOR_MODEL}_zuds_rec.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_conformal_${CLIC_DETECTOR_MODEL}_zuds_dst.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/ CONFIGURATIONS valgrind
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
-  REQUIRED_FILES "/eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_37.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLIC_o3_v13/SIM/00008258/000/gghad_sim_8258_38.slcio"
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
+  REQUIRED_FILES ${EOS_BACKGROUND_FILE}
   TIMEOUT 300000
   )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_profile" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds_profile" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/Profiler.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so
   amplxe-cl -collect hotspots -r ../ClicReco/r@@@{at}
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Tracking=Conformal
   --global.MaxRecordNumber=10
-  --Output_REC.LCIOOutputFile=reco_conformal_v13_zuds_rec_prof.slcio
-  --Output_DST.LCIOOutputFile=reco_conformal_v13_zuds_dst_prof.slcio
+  --Output_REC.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_rec_prof.slcio
+  --Output_DST.LCIOOutputFile=reco_conformal_${CLIC_DETECTOR_MODEL}_zuds_dst_prof.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   CONFIGURATIONS PROF
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
   TIMEOUT 300000
   )
 
 
-SET( test_name "test_CLIC_o3_v13_reco_conformal_zuds_overlay_profile" )
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_conformal_zuds_overlay_profile" )
 ADD_TEST( NAME t_${test_name}
   COMMAND
   ${CMAKE_SOURCE_DIR}/Tests/bin/Profiler.sh ${CMAKE_SOURCE_DIR}/lib/libClicPerformance.so
   amplxe-cl -collect hotspots -r ../ClicReco/r@@@{at}_over
   Marlin
-  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
-  --global.LCIOInputFiles=testCLIC_o3_v13_zuds.slcio clicReconstruction.xml
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=test${CLIC_DETECTOR_MODEL}_zuds.slcio clicReconstruction.xml
   --Config.Overlay=3TeV
   --Config.Tracking=Conformal
-  --Overlay3TeV.BackgroundFileNames="gghad_sim_8494_37.slcio gghad_sim_8494_38.slcio"
+  --Overlay3TeV.BackgroundFileNames=${EOS_BACKGROUND_FILE}
   --global.MaxRecordNumber=1
-  --Output_REC.LCIOOutputFile=reco_overlay_conformal_v13_zuds_rec_over_prof.slcio
-  --Output_DST.LCIOOutputFile=reco_overlay_conformal_v13_zuds_dst_over_prof.slcio
+  --Output_REC.LCIOOutputFile=reco_overlay_conformal_${CLIC_DETECTOR_MODEL}_zuds_rec_over_prof.slcio
+  --Output_DST.LCIOOutputFile=reco_overlay_conformal_${CLIC_DETECTOR_MODEL}_zuds_dst_over_prof.slcio
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
   CONFIGURATIONS PROF
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
   FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error"
-  DEPENDS test_CLIC_o3_v13_sim_zuds
-  REQUIRED_FILES "gghad_sim_8494_37.slcio;gghad_sim_8494_38.slcio"
+  DEPENDS test_${CLIC_DETECTOR_MODEL}_sim_zuds
+  REQUIRED_FILES ${EOS_BACKGROUND_FILE}
   TIMEOUT 300000
   )

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -12,6 +12,11 @@
     <processor name="InitDD4hep"/>
     <processor name="Config" />
 
+
+    <if condition="Config.OverlayFalse">
+      <processor name="OverlayFalse"/>
+    </if>
+
     <if condition="Config.Overlay350GeV">
       <processor name="Overlay350GeV"/>
     </if>
@@ -169,6 +174,12 @@
       gghad_01.slcio
       gghad_02.slcio
     </parameter>
+
+      <processor name="OverlayFalse" type="OverlayTimingGeneric">
+        <parameter name="BackgroundFileNames" type="StringVec"> </parameter>
+        <parameter name="NBunchtrain" type="int" value="0"/>
+        <parameter name="NumberBackground" type="float" value="0."/>
+      </processor>
 
       <processor name="Overlay350GeV" type="OverlayTimingGeneric">
         <parameter name="NumberBackground" type="float" value="0.0464"/>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -971,7 +971,7 @@
     <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
 
-  <processor name="LumiCalReco" type="MarlinLumiCalClusterer">
+  <processor name="LumiCalReco_Obs" type="MarlinLumiCalClusterer">
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <parameter name="Verbosity" type="string"> WARNING </parameter>
     <!--Collection Containing the Hits in the LumiCal-->
@@ -1017,6 +1017,64 @@
     <parameter name="WeightingMethod" type="string"> LogMethod </parameter>
     <!-- Layers relative phi offset (default for model ILD_o1_05,must go to gear sometimes)  [deg]-->
     <parameter name="ZLayerPhiOffset" type="double"> 0.0 </parameter>
+  </processor>
+
+
+  <processor name="LumiCalReco" type="BeamCalClusterReco">
+    <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
+    <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged, Empty]-->
+    <parameter name="BackgroundMethod" type="string">Empty </parameter>
+    <!--The Name of the Detector the reconstruction is for-->
+    <parameter name="DetectorName" type="string">LumiCal </parameter>
+    <!--The ID of the first layer of the detector BeamCal 1: LumiCal: 0-->
+    <parameter name="DetectorStartingLayerID" type="double"> 0 </parameter>
+    <!--Collection of CalorimeterHits from the BeamCal,only created when input are SimCalorimeterHits-->
+    <parameter name="BeamCalHitsOutCollection" type="string" lcioOutType="CalorimeterHit">LumiCal_Hits </parameter>
+    <!--Name of BeamCal Collection-->
+    <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">LumiCalCollection </parameter>
+    <!--Name of the Reconstructed Cluster collection-->
+    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">LumiCalClusters </parameter>
+    <!--Name of the Reconstructed Particle collection-->
+    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">LumiCalRecoParticles </parameter>
+    <!--MCParticle Collection Name, only needed and used to estimate efficiencies-->
+    <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
+    <!--Multiply deposit energy by this factor to account for sampling fraction-->
+    <parameter name="LinearCalibrationFactor" type="double"> 82.377 </parameter>
+    <!--Weighting constant to use in logarithmic weighting of hits, if negative energy weighting is used-->
+    <parameter name="LogWeightingConstant" type="double"> 6.1 </parameter>
+    <!--Maximum Distance between primary tower and neighbours to put into one cluster-->
+    <parameter name="MaxPadDistance" type="double"> 62 </parameter>
+    <!--Number of Bunch Crossings of Background-->
+    <parameter name="NumberOfBX" type="int"> 0 </parameter>
+    <!--Flag to create the TEfficiency for fast tagging library-->
+    <parameter name="CreateEfficiencyFile" type="bool">false </parameter>
+    <!--The name of the rootFile which will contain the TEfficiency objects-->
+    <parameter name="EfficiencyFilename" type="string">TaggingEfficiency.root </parameter>
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <parameter name="Verbosity" type="string">DEBUG0 </parameter>
+    <!--Number of Event that should be printed to PDF File-->
+    <parameter name="PrintThisEvent" type="int">-1 </parameter>
+    <parameter name="InputFileBackgrounds" type="StringVec"> </parameter>
+    <!--Rings from which onwards the outside Thresholds are used-->
+    <parameter name="StartingRing" type="FloatVec">0.0 </parameter>
+    <!--Energy in a Cluster to consider it an electron-->
+    <parameter name="ETCluster" type="FloatVec"> 0.2 </parameter>
+    <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
+    <parameter name="ETPad" type="FloatVec"> 20e-06 </parameter>
+    <!--Layer (inclusive) from which on we start looking for signal clusters-->
+    <parameter name="StartLookingInLayer" type="int">1 </parameter>
+    <!--Use the cuts for the pads specified in ETPad. If false, the standard deviation of each pad times the SigmaCut Factor is used, the first entry in ETPad is used as a minimum energy to consider a pad at all-->
+    <parameter name="UseConstPadCuts" type="bool">false </parameter>
+    <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
+    <parameter name="SigmaCut" type="double">1 </parameter>
+    <!--Minimum number of pads in a single tower to be considered for signal-->
+    <parameter name="MinimumTowerSize" type="int">4 </parameter>
+    <!--How many layers are used for shower fitting-->
+    <parameter name="NShowerCountingLayers" type="int">30 </parameter>
+    <!--Limit on square norm of tower eqnergy chi2/ndf, where chi2 = (E_dep - E_bg)^2/sig^2. Reasonable value for pregenerated bkg is 5., for parametrised is 2.-->
+    <parameter name="TowerChi2ndfLimit" type="double">5 </parameter>
+    <!--Use Chi2 selection criteria to detect high energy electron in the signal.-->
+    <parameter name="UseChi2Selection" type="bool">false </parameter>
   </processor>
 
 

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -74,6 +74,8 @@
       <processor name="BeamCalReco380GeV"/>
     </if>
 
+    <group name="MergeCollections" />
+
     <!-- ========== monitoring  ========== -->
     <processor name="MyClicEfficiencyCalculator"/>
     <processor name="MyRecoMCTruthLinker"/>
@@ -846,11 +848,22 @@
     <parameter name="RelationOutputCollection" type="string">RelationMuonHit </parameter>
   </processor>
 
-  <processor name="MyStatusmonitor" type="Statusmonitor">
-    <parameter name="HowOften" type="int">100</parameter>
-    <parameter name="Verbosity" type="string">MESSAGE </parameter>
-  </processor>
+  <group name="MergeCollections">
 
+    <processor name="MergeRP" type="MergeCollections">
+      <parameter name="CollectionParameterIndex" type="int">0 </parameter>
+      <parameter name="InputCollectionIDs" type="IntVec"> </parameter>
+      <parameter name="InputCollections" type="StringVec"> PandoraPFOs LumiCalRecoParticles BeamCalRecoParticles </parameter>
+      <parameter name="OutputCollection" type="string"> MergedRecoParticles </parameter>
+    </processor>
+
+    <processor name="MergeClusters" type="MergeCollections">
+      <parameter name="CollectionParameterIndex" type="int">0 </parameter>
+      <parameter name="InputCollectionIDs" type="IntVec"> </parameter>
+      <parameter name="InputCollections" type="StringVec"> PandoraClusters LumiCalClusterer BeamCalClusters </parameter>
+      <parameter name="OutputCollection" type="string"> MergedClusters </parameter>
+    </processor>
+  </group>
 
   <processor name="MyRecoMCTruthLinker" type="RecoMCTruthLinker">
     <!--links RecontructedParticles to the MCParticle based on number of hits used-->
@@ -859,7 +872,7 @@
     <!--Name of the updated calo-hit MCTruthLink output collection - not created if empty()-->
     <parameter name="CalohitMCTruthLinkName" type="string" lcioOutType="LCRelation"> CalohitMCTruthLink </parameter>
     <!--Name of the Clusters input collection-->
-    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">PandoraClusters </parameter>
+    <parameter name="ClusterCollection" type="string" lcioInType="Cluster">MergedClusters </parameter>
     <!--Name of the clusterMCTruthLink output collection - not created if empty()-->
     <parameter name="ClusterMCTruthLinkName" type="string" lcioOutType="LCRelation"> ClusterMCTruthLink </parameter>
     <!--true: All reco <-> true relations are given, with weight = 10000*calo
@@ -872,7 +885,7 @@
     <!-- FIXME:Check if we really want to keep those -->
     <parameter name="KeepDaughtersPDG" type="IntVec">22 111 310 13 211 321 3120 </parameter>
     <!--Name of the MCParticle input collection-->
-    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCPhysicsParticles </parameter>
     <!--Name of the skimmed MCParticle  output collection - not created if empty()-->
     <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmed </parameter>
     <!--Name of the MCTruthClusterLink output collection-->
@@ -884,7 +897,7 @@
     <!--Name of the RecoMCTruthLink output collection - not created if empty()-->
     <parameter name="RecoMCTruthLinkName" type="string" lcioOutType="LCRelation"> RecoMCTruthLink </parameter>
     <!--Name of the ReconstructedParticles input collection-->
-    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
+    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> MergedRecoParticles </parameter>
     <!--save photons from Brems-->
     <parameter name="SaveBremsstrahlungPhotons" type="bool">false </parameter>
     <!--Names of the SimCaloHits input collections-->
@@ -1360,6 +1373,7 @@
       Track
       ReconstructedParticle
       LCFloatVec
+      Clusters
     </parameter>
     <parameter name="KeepCollectionNames" type="StringVec">
       MCParticlesSkimmed
@@ -1378,6 +1392,8 @@
       LumiCalRecoParticles
       BeamCalClusters
       BeamCalRecoParticles
+      MergedRecoParticles
+      MergedClusters
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
     <parameter name="Verbosity" type="string">WARNING </parameter>


### PR DESCRIPTION

BEGINRELEASENOTES
- Use BeamCalReco for LumiCal reconstruction
- Merge Cluster collections and feed all to RecoMCTruthLiner
- Merge ReconstructedParticle collections and feed all o RecoMCTruthLinker
- Only gives physics particles to RecoMCTruthLinker
- Switch Tests to CLIC_o3_v14

ENDRELEASENOTES