### PR TITLE
Fcc steering files

### DIFF
--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -84,7 +84,7 @@
   </processor>
 
   <processor name="Config" type="CLICRecoConfig" >
-    <!--Which option to use for overlay: False, 3TeV, 380GeV. Then use, e.g., Config.Overlay3TeV in the condition-->
+    <!--Which option to use for overlay: False, 91GeV, 365GeV. Then use, e.g., Config.Overlay91GeV in the condition-->
     <parameter name="Overlay" type="string">False </parameter>
     <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal-->
     <parameter name="Tracking" type="string">Truth </parameter>
@@ -100,28 +100,28 @@
     <parameter name="NBunchtrain" type="int" value="20"/>
 
     <parameter name="Collection_IntegrationTimes" type="StringVec" >
-      VertexBarrelCollection        10
-      VertexEndcapCollection        10
+      VertexBarrelCollection        380
+      VertexEndcapCollection        380
 
-      InnerTrackerBarrelCollection  10
-      InnerTrackerEndcapCollection  10
+      InnerTrackerBarrelCollection  380
+      InnerTrackerEndcapCollection  380
 
-      OuterTrackerBarrelCollection  10
-      OuterTrackerEndcapCollection  10
+      OuterTrackerBarrelCollection  380
+      OuterTrackerEndcapCollection  380
 
-      ECalBarrelCollection          10
-      ECalEndcapCollection          10
-      ECalPlugCollection            10
+      ECalBarrelCollection          380
+      ECalEndcapCollection          380
+      ECalPlugCollection            380
 
-      HCalBarrelCollection          10
-      HCalEndcapCollection          10
-      HCalRingCollection            10
+      HCalBarrelCollection          380
+      HCalEndcapCollection          380
+      HCalRingCollection            380
 
-      YokeBarrelCollection          10
-      YokeEndcapCollection          10
+      YokeBarrelCollection          380
+      YokeEndcapCollection          380
 
-      LumiCalCollection             10
-      BeamCalCollection             10
+      LumiCalCollection             380
+      BeamCalCollection             380
     </parameter>
     <!--Number of the Bunch crossing of the physics event-->
     <parameter name="PhysicsBX" type="int" value="1"/>

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -8,24 +8,12 @@
     <processor name="InitDD4hep"/>
     <processor name="Config" />
 
-    <if condition="Config.Overlay350GeV">
-      <processor name="Overlay350GeV"/>
+    <if condition="Config.Overlay91GeV">
+      <processor name="Overlay91GeV"/>
     </if>
 
-    <if condition="Config.Overlay380GeV">
-      <processor name="Overlay380GeV"/>
-    </if>
-
-    <if condition="Config.Overlay500GeV">
-      <processor name="Overlay500GeV"/>
-    </if>
-
-    <if condition="Config.Overlay1.4TeV">
-      <processor name="Overlay1.4TeV"/>
-    </if>
-
-    <if condition="Config.Overlay3TeV">
-      <processor name="Overlay3TeV"/>
+    <if condition="Config.Overlay365GeV">
+      <processor name="Overlay365GeV"/>
     </if>
 
     <!-- ========== digitisation  ========== -->
@@ -56,7 +44,6 @@
     <processor name="MyDDSimpleMuonDigi"/> 
     <processor name="MyDDMarlinPandora"/> 
     <processor name="LumiCalReco"/>
-    <processor name="BeamCalReco"/>
 
     <!-- ========== monitoring  ========== -->
     <processor name="MyClicEfficiencyCalculator"/>
@@ -108,9 +95,9 @@
     <!--The output MC Particle Collection Name for the physics event-->
     <parameter name="MCPhysicsParticleCollectionName" type="string"> MCPhysicsParticles </parameter>
     <!--Time difference between bunches in the bunch train in ns-->
-    <parameter name="Delta_t" type="float" value="0.5"/>
+    <parameter name="Delta_t" type="float" value="20"/>
     <!--Number of bunches in a bunch train-->
-    <parameter name="NBunchtrain" type="int" value="30"/>
+    <parameter name="NBunchtrain" type="int" value="20"/>
 
     <parameter name="Collection_IntegrationTimes" type="StringVec" >
       VertexBarrelCollection        10
@@ -137,40 +124,23 @@
       BeamCalCollection             10
     </parameter>
     <!--Number of the Bunch crossing of the physics event-->
-    <parameter name="PhysicsBX" type="int" value="10"/>
+    <parameter name="PhysicsBX" type="int" value="1"/>
     <!--Draw random number of Events to overlay from Poisson distribution with  mean value NumberBackground-->
-    <parameter name="Poisson_random_NOverlay" type="bool" value="true"/>
+    <parameter name="Poisson_random_NOverlay" type="bool" value="false"/>
     <!--Place the physics event at an random position in the train - overrides PhysicsBX-->
     <parameter name="RandomBx" type="bool" value="false"/>
     <!--[mm/ns] (float) - default 5.0e-2 (5cm/us)-->
     <parameter name="TPCDriftvelocity" type="float" value="0.05"/>
     <parameter name="BackgroundFileNames" type="StringVec">
-      gghad_01.slcio
-      gghad_02.slcio
+      pairs_Z_sim.slcio
     </parameter>
 
-      <processor name="Overlay350GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="0.0464"/>
+      <processor name="Overlay91GeV" type="OverlayTimingGeneric">
+        <parameter name="NumberBackground" type="float" value="1."/>
       </processor>
 
-      <processor name="Overlay380GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="0.0464"/>
-      </processor>
-
-      <processor name="Overlay420GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="0.17"/>
-      </processor>
-
-      <processor name="Overlay500GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="0.3"/>
-      </processor>
-
-      <processor name="Overlay1.4TeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="1.3"/>
-      </processor>
-
-      <processor name="Overlay3TeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="3.2"/>
+      <processor name="Overlay365GeV" type="OverlayTimingGeneric">
+        <parameter name="NumberBackground" type="float" value="1."/>
       </processor>
   </group>
 
@@ -963,54 +933,6 @@
     <parameter name="ZLayerPhiOffset" type="double"> 0.0 </parameter>
   </processor>
 
-
-  <processor name="BeamCalReco" type="BeamCalClusterReco">
-    <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
-    <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged]-->
-    <parameter name="BackgroundMethod" type="string">Gaussian </parameter>
-    <!--Name of BeamCal Collection-->
-    <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">BeamCalCollection </parameter>
-    <!--Flag to create the TEfficiency for fast tagging library-->
-    <parameter name="CreateEfficiencyFile" type="bool">false </parameter>
-    <!--Rings from which onwards the outside Thresholds are used-->
-    <parameter name="StartingRing" type="FloatVec">0.0 1.0 1.5 2.5 3.5  4.5 </parameter>
-    <!--Energy in a Cluster to consider it an electron-->
-    <parameter name="ETCluster" type="FloatVec">   5.0 4.0 3.0 2.0 2.0  1.0 </parameter>
-    <!--Energy in a Pad, after subtraction of background required to consider it for signal-->
-    <parameter name="ETPad" type="FloatVec">       0.5 0.4 0.3 0.2 0.15 0.1 </parameter>
-    <!--The name of the rootFile which will contain the TEfficiency objects-->
-    <parameter name="EfficiencyFilename" type="string">TaggingEfficiency.root </parameter>
-    <!--Root Inputfile(s)-->
-    <parameter name="InputFileBackgrounds" type="StringVec">BeamCal_BackgroundPars_3TeV.root </parameter>
-    <!--Multiply deposit energy by this factor to account for sampling fraction-->
-    <parameter name="LinearCalibrationFactor" type="double">116.44 </parameter>
-    <!--MCParticle Collection Name, only needed and used to estimate efficiencies-->
-    <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
-    <!--Minimum number of pads in a single tower to be considered for signal-->
-    <parameter name="MinimumTowerSize" type="int">4 </parameter>
-    <!--How many layers are used for shower fitting-->
-    <parameter name="NShowerCountingLayers" type="int">3 </parameter>
-    <!--Number of Bunch Crossings of Background-->
-    <parameter name="NumberOfBX" type="int"> 40 </parameter>
-    <!--Number of Event that should be printed to PDF File-->
-    <parameter name="PrintThisEvent" type="int">-1 </parameter>
-    <!--Name of the Reconstructed Cluster collection-->
-    <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">BCalClusters </parameter>
-    <!--Name of the Reconstructed Particle collection-->
-    <parameter name="RecoParticleCollectionname" type="string" lcioOutType="ReconstructedParticle">BCalRecoParticle </parameter>
-    <!--If not using ConstPadCuts, each pad SigmaCut*standardDeviation is considered for clusters-->
-    <parameter name="SigmaCut" type="double">1 </parameter>
-    <!--Layer (inclusive) from which on we start looking for signal clusters-->
-    <parameter name="StartLookingInLayer" type="int">10 </parameter>
-    <!--Limit on square norm of tower energy chi2/ndf, where chi2 = (E_dep - E_bg)^2/sig^2. 			      Reasonable value for pregenerated bkg is 5., for parametrised is 2.-->
-    <parameter name="TowerChi2ndfLimit" type="double">5 </parameter>
-    <!--Use Chi2 selection criteria to detect high energy electron in the signal.-->
-    <parameter name="UseChi2Selection" type="bool">false </parameter>
-    <!--Use the cuts for the pads specified in ETPad. If false, the standard deviation of each pad times the SigmaCut Factor is used, the first entry in ETPad is used as a minimum energy to consider a pad at all-->
-    <parameter name="UseConstPadCuts" type="bool">true </parameter>
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
-  </processor>
 
   <group name="PfoSelector">
     <!--Selects Pfos from full PFO list using timing cuts-->

--- a/examples/fcc_steer.py
+++ b/examples/fcc_steer.py
@@ -1,0 +1,239 @@
+import os
+
+from DDSim.DD4hepSimulation import DD4hepSimulation
+from SystemOfUnits import mm, GeV, MeV, m
+SIM = DD4hepSimulation()
+
+## The compact XML file
+SIM.compactFile = ""
+## Lorentz boost for the crossing angle, in radian!
+SIM.crossingAngleBoost = 0.015
+SIM.enableDetailedShowerMode = True
+SIM.enableG4GPS = False
+SIM.enableG4Gun = False
+SIM.enableGun = False
+## InputFiles for simulation .stdhep, .slcio, .HEPEvt, .hepevt, .hepmc files are supported
+SIM.inputFiles = []
+## Macro file to execute for runType 'run' or 'vis'
+SIM.macroFile = ""
+## number of events to simulate, used in batch mode
+SIM.numberOfEvents = 0
+## Outputfile from the simulation,only lcio output is supported
+SIM.outputFile = "dummyOutput.slcio"
+## Verbosity use integers from 1(most) to 7(least) verbose
+## or strings: VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL, ALWAYS
+SIM.printLevel = 3
+## The type of action to do in this invocation
+## batch: just simulate some events, needs numberOfEvents, and input file or gun
+## vis: enable visualisation, run the macroFile if it is set
+## run: run the macroFile and exit
+## shell: enable interactive session
+SIM.runType = "batch"
+## Skip first N events when reading a file
+SIM.skipNEvents = 0
+## Steering file to change default behaviour
+SIM.steeringFile = None
+## FourVector of translation for the Smearing of the Vertex position: x y z t
+SIM.vertexOffset = [0.0, 0.0, 0.0, 0.0]
+## FourVector of the Sigma for the Smearing of the Vertex position: x y z t
+SIM.vertexSigma = [0.0, 0.0, 0.0, 0.0]
+
+
+################################################################################
+## Action holding sensitive detector actions
+##   The default tracker and calorimeter actions can be set with
+## 
+##   >>> SIM = DD4hepSimulation()
+##   >>> SIM.action.tracker = "Geant4TrackerAction"
+##   >>> SIM.action.calo    = "Geant4CalorimeterAction"
+## 
+##   for specific subdetectors specific sensitive detectors can be set based on pattern matching
+## 
+##   >>> SIM = DD4hepSimulation()
+##   >>> SIM.action.mapActions['tpc'] = "TPCSDAction"
+## 
+##   and additional parameters for the sensitive detectors can be set when the map is given a tuple
+## 
+##   >>> SIM = DD4hepSimulation()
+##   >>> SIM.action.mapActions['ecal'] =( "CaloPreShowerSDAction", {"FirstLayerNumber": 1} )
+## 
+##    
+################################################################################
+
+##  set the default tracker action 
+SIM.action.tracker = "Geant4TrackerWeightedAction" 
+
+##  set the default calorimeter action 
+SIM.action.calo = "Geant4ScintillatorCalorimeterAction"
+
+##  create a map of patterns and actions to be applied to sensitive detectors
+##         example: SIM.action.mapActions['tpc'] = "TPCSDAction" 
+SIM.action.mapActions = {}
+
+
+################################################################################
+## Configuration for the magnetic field (stepper) 
+################################################################################
+SIM.field.delta_chord = 0.25*mm
+SIM.field.delta_intersection = 0.001*mm
+SIM.field.delta_one_step = 0.01*mm
+SIM.field.eps_max = 0.001*mm
+SIM.field.eps_min = 5e-05*mm
+SIM.field.equation = "Mag_UsualEqRhs"
+SIM.field.largest_step = 10.0*m
+SIM.field.min_chord_step = 0.01*mm
+SIM.field.stepper = "G4ClassicalRK4"
+
+
+################################################################################
+## Configuration for sensitive detector filters
+## 
+##   Set the default filter for tracker or caliromter
+##   >>> SIM.filter.tracker = "edep1kev"
+##   >>> SIM.filter.calo = ""
+## 
+##   Assign a filter to a sensitive detector via pattern matching
+##   >>> SIM.filter.mapDetFilter['FTD'] = "edep1kev"
+## 
+##   Or more than one filter:
+##   >>> SIM.filter.mapDetFilter['FTD'] = ["edep1kev", "geantino"]
+## 
+##   Don't use the default filter or anything else:
+##   >>> SIM.filter.mapDetFilter['TPC'] = None ## or "" or []
+## 
+##   Create a custom filter. The dictionary is used to instantiate the filter later on
+##   >>> SIM.filter.filters['edep3kev'] = dict(name="EnergyDepositMinimumCut/3keV", parameter={"Cut": 3.0*keV} )
+## 
+##    
+################################################################################
+
+##  default filter for calorimeter sensitive detectors; this is applied if no other filter is used for a calorimeter 
+SIM.filter.calo = "edep0"
+
+##  list of filter objects: map between name and parameter dictionary 
+SIM.filter.filters = {'edep0': {'parameter': {'Cut': 0.0}, 'name': 'EnergyDepositMinimumCut/Cut0'}, 'geantino': {'parameter': {}, 'name': 'GeantinoRejectFilter/GeantinoRejector'}, 'edep1kev': {'parameter': {'Cut': 0.001}, 'name': 'EnergyDepositMinimumCut'}}
+
+##  a map between patterns and filter objects, using patterns to attach filters to sensitive detector 
+SIM.filter.mapDetFilter = {}
+
+##  default filter for tracking sensitive detectors; this is applied if no other filter is used for a tracker
+SIM.filter.tracker = "edep1kev"
+
+
+################################################################################
+## Configuration for the DDG4 ParticleGun 
+################################################################################
+
+##  direction of the particle gun, 3 vector 
+SIM.gun.direction = (0, 0, 1)
+
+## choose the distribution of the random direction for theta
+## 
+##     Options for random distributions:
+## 
+##     'uniform' is the default distribution, flat in theta
+##     'cos(theta)' is flat in cos(theta)
+##     'eta', or 'pseudorapidity' is flat in pseudorapity
+##     'ffbar' is distributed according to 1+cos^2(theta)
+## 
+##     Setting a distribution will set isotrop = True
+##     
+SIM.gun.distribution = None
+SIM.gun.energy = 10000.0
+
+##  isotropic distribution for the particle gun
+## 
+##     use the options phiMin, phiMax, thetaMin, and thetaMax to limit the range of randomly distributed directions
+##     if one of these options is not None the random distribution will be set to True and cannot be turned off!
+##     
+SIM.gun.isotrop = False
+SIM.gun.multiplicity = 1
+SIM.gun.particle = "mu-"
+SIM.gun.phiMax = None
+
+## Minimal azimuthal angle for random distribution
+SIM.gun.phiMin = None
+
+##  position of the particle gun, 3 vector 
+SIM.gun.position = (0.0, 0.0, 0.0)
+SIM.gun.thetaMax = None
+SIM.gun.thetaMin = None
+
+
+################################################################################
+## Configuration for the output levels of DDG4 components 
+################################################################################
+
+## Output level for input sources
+SIM.output.inputStage = 3
+
+## Output level for Geant4 kernel
+SIM.output.kernel = 3
+
+## Output level for ParticleHandler
+SIM.output.part = 3
+
+## Output level for Random Number Generator setup
+SIM.output.random = 6
+
+
+################################################################################
+## Configuration for the Particle Handler/ MCTruth treatment 
+################################################################################
+
+##  Keep all created particles 
+SIM.part.keepAllParticles = False
+
+## Minimal distance between particle vertex and endpoint of parent after
+##     which the vertexIsNotEndpointOfParent flag is set
+##     
+SIM.part.minDistToParentVertex = 2.2e-14
+
+## MinimalKineticEnergy to store particles created in the tracking region
+SIM.part.minimalKineticEnergy = 1.0*MeV
+
+##  Printout at End of Tracking 
+SIM.part.printEndTracking = False
+
+##  Printout at Start of Tracking 
+SIM.part.printStartTracking = False
+
+## List of processes to save, on command line give as whitespace separated string in quotation marks
+SIM.part.saveProcesses = ['Decay']
+
+
+################################################################################
+## Configuration for the PhysicsList 
+################################################################################
+SIM.physics.decays = True
+SIM.physics.list = "FTFP_BERT"
+
+##  location of particle.tbl file containing extra particles and their lifetime information
+##     
+SIM.physics.pdgfile = os.path.join( os.environ.get("DD4HEP"), "DDG4/examples/particle.tbl" )
+
+##  The global geant4 rangecut for secondary production
+## 
+##     Default is 0.7 mm as is the case in geant4 10
+## 
+##     To disable this plugin and be absolutely sure to use the Geant4 default range cut use "None"
+## 
+##     Set printlevel to DEBUG to see a printout of all range cuts,
+##     but this only works if range cut is not "None"
+##     
+SIM.physics.rangecut = 0.7*mm
+
+
+################################################################################
+## Properties for the random number generator 
+################################################################################
+
+## If True, calculate random seed for each event based on eventID and runID
+## allows reproducibility even when SkippingEvents
+SIM.random.enableEventSeed = True
+SIM.random.file = None
+SIM.random.luxury = 1
+SIM.random.replace_gRandom = True
+SIM.random.seed = None
+SIM.random.type = None
+

--- a/source/Conditions/include/CLICRecoConfig.h
+++ b/source/Conditions/include/CLICRecoConfig.h
@@ -42,7 +42,7 @@ protected:
   std::string m_trackingChoice="Truth";
 
   // Overlay
-  const Choices m_overlayPossibleOptions{"False", "350GeV", "380GeV", "420GeV", "500GeV", "1.4TeV", "3TeV"};
+  const Choices m_overlayPossibleOptions{"False", "91GeV", "350GeV", "365GeV",  "380GeV", "420GeV", "500GeV", "1.4TeV", "3TeV"};
   std::string m_overlayChoice="False";
 
   // BeamCal


### PR DESCRIPTION
BEGINRELEASENOTES
- **fcc_steer.py**: Lorentz boost set to 0.015 rad [NB: to be used on pairs files only if those have been produced without crossing angle. If this is not the case, set the Lorentz boost to 0.0]
- **fccReconstruction.xml**: adjusted Overlay parameters to FCCee (number of BX, Delta_t, integration time windows per subdetector, number of events to overlay = 1 -- not Poissonian -- given that the gen files from GuineaPig contain 1 evt per file) and removed BeamCalReco (not available for FCCee yet)
- **CLICRecoConfig.h**: added two options for FCCee background overlay (91GeV, 365GeV)
ENDRELEASENOTES