### PR TITLE
clicReconstruction.xml (and fccReconstruction.xml): added configuration for ClonesAndSplitTracksF…

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -449,8 +449,8 @@
   </processor>
 
   <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
-    <parameter name="InputTrackCollection" type="string"> SiTracksCT </parameter>
-    <parameter name="OutputTrackCollection" type="string"> SiTracks </parameter>
+    <parameter name="InputTrackCollectionName" type="string"> SiTracksCT </parameter>
+    <parameter name="OutputTrackCollectionName" type="string"> SiTracks </parameter>
     <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -56,6 +56,7 @@
     </if>
     <if condition="Config.TrackingConformal">
       <processor name="MyConformalTrackingFull"/>
+      <processor name="ClonesAndSplitTracksFinder"/>
     </if>
 
     <processor name="Refit" />
@@ -447,6 +448,18 @@
     <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
 
+  <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
+    <parameter name="InputTrackCollection" type="string"> SiTracks </parameter>
+    <parameter name="OutputTrackCollection" type="string"> SiTracksMerged </parameter>
+    <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+    <parameter name="EnergyLossOn" type="bool"> true </parameter>
+    <parameter name="SmoothOn" type="bool"> false </parameter>
+    <parameter name="extrapolateForward" type="bool"> true </parameter>
+    <parameter name="maxDeltaTheta" type="double"> 0.59 </parameter>
+    <parameter name="maxDeltaPhi" type="double"> 0.99 </parameter>
+    <parameter name="maxDeltaPt" type="double"> 0.69 </parameter>
+  </processor>
+
   <processor name="Refit" type="RefitFinal">
     <!--Refit processor that calls finaliseLCIOTrack after taking the trackstate from the existing track. No re-sorting of hits is done-->
     <!--Use Energy Loss in Fit-->
@@ -454,7 +467,7 @@
     <!--Name of the input track to MCParticle relation collection-->
     <parameter name="InputRelationCollectionName" type="string" lcioInType="LCRelation"> SiTrackRelations </parameter>
     <!--Name of the input track collection-->
-    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracksMerged </parameter>
     <!--maximum allowable chi2 increment when moving from one site to another-->
     <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
     <!--Use MultipleScattering in Fit-->

--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -441,7 +441,7 @@
     <parameter name="RetryTooManyTracks" type="bool">false </parameter>
 
     <!--Silicon track Collection Name-->
-    <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracks </parameter>
+    <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
     <!--Name of the MCParticle input collection-->
     <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
@@ -449,8 +449,8 @@
   </processor>
 
   <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
-    <parameter name="InputTrackCollection" type="string"> SiTracks </parameter>
-    <parameter name="OutputTrackCollection" type="string"> SiTracksMerged </parameter>
+    <parameter name="InputTrackCollection" type="string"> SiTracksCT </parameter>
+    <parameter name="OutputTrackCollection" type="string"> SiTracks </parameter>
     <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>
@@ -467,7 +467,7 @@
     <!--Name of the input track to MCParticle relation collection-->
     <parameter name="InputRelationCollectionName" type="string" lcioInType="LCRelation"> SiTrackRelations </parameter>
     <!--Name of the input track collection-->
-    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracksMerged </parameter>
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
     <!--maximum allowable chi2 increment when moving from one site to another-->
     <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
     <!--Use MultipleScattering in Fit-->

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -372,7 +372,7 @@
     <parameter name="trackPurity" type="double">0.7 </parameter>
 
     <!--Silicon track Collection Name-->
-    <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracks </parameter>
+    <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
     <!--Name of the MCParticle input collection-->
     <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
@@ -380,8 +380,8 @@
   </processor>
 
   <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
-    <parameter name="InputTrackCollection" type="string"> SiTracks </parameter>
-    <parameter name="OutputTrackCollection" type="string"> SiTracksMerged </parameter>
+    <parameter name="InputTrackCollection" type="string"> SiTracksCT </parameter>
+    <parameter name="OutputTrackCollection" type="string"> SiTracks </parameter>
     <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>
@@ -398,7 +398,7 @@
     <!--Name of the input track to MCParticle relation collection-->
     <parameter name="InputRelationCollectionName" type="string" lcioInType="LCRelation"> SiTrackRelations </parameter>
     <!--Name of the input track collection-->
-    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracksMerged </parameter>
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
     <!--maximum allowable chi2 increment when moving from one site to another-->
     <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
     <!--Use MultipleScattering in Fit-->

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -35,6 +35,7 @@
     </if>
     <if condition="Config.ConformalTracking">
       <processor name="MyConformalTrackingFull"/>
+      <processor name="ClonesAndSplitTracksFinder"/>
     </if>
 
     <processor name="Refit" />
@@ -378,6 +379,18 @@
     <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
   </processor>
 
+  <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
+    <parameter name="InputTrackCollection" type="string"> SiTracks </parameter>
+    <parameter name="OutputTrackCollection" type="string"> SiTracksMerged </parameter>
+    <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
+    <parameter name="EnergyLossOn" type="bool"> true </parameter>
+    <parameter name="SmoothOn" type="bool"> false </parameter>
+    <parameter name="extrapolateForward" type="bool"> true </parameter>
+    <parameter name="maxDeltaTheta" type="double"> 0.59 </parameter>
+    <parameter name="maxDeltaPhi" type="double"> 0.99 </parameter>
+    <parameter name="maxDeltaPt" type="double"> 0.69 </parameter>
+  </processor>
+
   <processor name="Refit" type="RefitFinal">
     <!--Refit processor that calls finaliseLCIOTrack after taking the trackstate from the existing track. No re-sorting of hits is done-->
     <!--Use Energy Loss in Fit-->
@@ -385,7 +398,7 @@
     <!--Name of the input track to MCParticle relation collection-->
     <parameter name="InputRelationCollectionName" type="string" lcioInType="LCRelation"> SiTrackRelations </parameter>
     <!--Name of the input track collection-->
-    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracks </parameter>
+    <parameter name="InputTrackCollectionName" type="string" lcioInType="Track"> SiTracksMerged </parameter>
     <!--maximum allowable chi2 increment when moving from one site to another-->
     <parameter name="Max_Chi2_Incr" type="double"> 1.79769e+30 </parameter>
     <!--Use MultipleScattering in Fit-->

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -380,8 +380,8 @@
   </processor>
 
   <processor name="ClonesAndSplitTracksFinder" type="ClonesAndSplitTracksFinder">
-    <parameter name="InputTrackCollection" type="string"> SiTracksCT </parameter>
-    <parameter name="OutputTrackCollection" type="string"> SiTracks </parameter>
+    <parameter name="InputTrackCollectionName" type="string"> SiTracksCT </parameter>
+    <parameter name="OutputTrackCollectionName" type="string"> SiTracks </parameter>
     <parameter name="MultipleScatteringOn" type="bool"> true </parameter>
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>


### PR DESCRIPTION
…inder

BEGINRELEASENOTES
- examples/clicReconstruction.xml: added configuration for ClonesAndSplitTracksFinder
- the processor is included in the Config.TrackingConformal condition, to run automatically after the conformal tracking
- the output track collection from ClonesAndSplitTracksFinder is given as input to RefitFinal
- analogous for fccReconstruction.xml
ENDRELEASENOTES