### PR TITLE
Reco: add parameters for collection names

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -406,6 +406,12 @@
 
     <!--Name of the TrackerHit input collections-->
     <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane"> VXDTrackerHits VXDEndcapTrackerHits ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits </parameter>
+    <!--Name of the TrackerHit input collections from the Vertex Barrel-->
+    <parameter name="VertexBarrelHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--Name of the TrackerHit input collections from the Vertex Endcap-->
+    <parameter name="VertexEndcapHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDEndcapTrackerHits </parameter>
+    <!--Name of the TrackerHit input collections from the Main Tracker-->
+    <parameter name="MainTrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits </parameter>
     <!--Name of the TrackerHit relation collections-->
     <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation"> VXDTrackerHitRelations VXDEndcapTrackerHitRelations InnerTrackerBarrelHitsRelations OuterTrackerBarrelHitsRelations InnerTrackerEndcapHitsRelations OuterTrackerEndcapHitsRelations </parameter>
 

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -295,8 +295,15 @@
 
     <!--Name of the TrackerHit input collections-->
     <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane"> VXDTrackerHits VXDEndcapTrackerHits ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits </parameter>
+    <!--Name of the TrackerHit input collections from the Vertex Barrel-->
+    <parameter name="VertexBarrelHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDTrackerHits </parameter>
+    <!--Name of the TrackerHit input collections from the Vertex Endcap-->
+    <parameter name="VertexEndcapHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">VXDEndcapTrackerHits </parameter>
+    <!--Name of the TrackerHit input collections from the Main Tracker-->
+    <parameter name="MainTrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">ITrackerHits OTrackerHits ITrackerEndcapHits OTrackerEndcapHits </parameter>
     <!--Name of the TrackerHit relation collections-->
     <parameter name="RelationsNames" type="StringVec" lcioInType="LCRelation"> VXDTrackerHitRelations VXDEndcapTrackerHitRelations InnerTrackerBarrelHitsRelations OuterTrackerBarrelHitsRelations InnerTrackerEndcapHitsRelations OuterTrackerEndcapHitsRelations </parameter>
+
 
     <!--Cut values for the pattern recognition -->
     <parameter name="ThetaRange" type="double"> 0.05 </parameter>


### PR DESCRIPTION
Adding the parameters introduced in ilcsoft/ConformalTracking#34

BEGINRELEASENOTES
- CLICReco: ConformalTracking: add the new parameters for collection names in VXDBarrel/Endcap and MainTracker
- FCCReco: ConformalTracking: add the new parameters for collection names in VXDBarrel/Endcap and MainTracker

ENDRELEASENOTES