### PR TITLE
fccReconstruction: [ConformalTracking]tight cuts for combined vertex …

### DIFF
--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -315,6 +315,8 @@
     <parameter name="MaxChi2" type="double"> 100 </parameter>
     <parameter name="DebugPlots" type="bool"> false </parameter>
     <parameter name="trackPurity" type="double">0.7 </parameter>
+    <!-- TEMPORARY: flag to switch off tight cuts in combined vertex b+e-->
+    <parameter name="EnableTightCutsVertexCombined" type="bool"> false </parameter> 
 
     <!--Silicon track Collection Name-->
     <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>


### PR DESCRIPTION
…b+e switched off by default



BEGINRELEASENOTES
- fccReconstruction: in ConformalTracking settings, added processor parameter to enable/disable the tight cuts for the combined vertex barrel + endcap reconstruction 
- default = true (enabled)
- for FCCee, it needs to be disabled because of 10degrees tracks (2 hits in the vertex barrel + 6 in the endcap). Looser cuts allow to pick the vertex (b+e) hits in one track, otherwise tight cuts allow for a track made with a subset of hits, while the leftover hits are used for a second track
- the external processor parameter is a temporary solution

ENDRELEASENOTES