### PR TITLE
clicReconstruction: [ConformalTracking]added flag to enable tight cut…

### DIFF
--- a/examples/clicReconstruction.xml
+++ b/examples/clicReconstruction.xml
@@ -425,6 +425,8 @@
     <parameter name="MaxChi2" type="double"> 100 </parameter>
     <parameter name="DebugPlots" type="bool"> false </parameter>
     <parameter name="trackPurity" type="double">0.7 </parameter>
+    <!-- TEMPORARY: flag to switch off tight cuts in combined vertex b+e-->
+    <parameter name="EnableTightCutsVertexCombined" type="bool"> false </parameter> 
 
     <!--sort results from kdtree search-->
     <parameter name="SortTreeResults" type="bool">true </parameter>


### PR DESCRIPTION
…s in the vertex combined



BEGINRELEASENOTES
- clicReconstruction: in ConformalTracking, added flag to enable tight cuts in the vertex combined (barrel+endcap) hits reconstruction
- done similarly to fccReconstruction
- to be upgraded soon with a more elegant solution

ENDRELEASENOTES