### PR TITLE
fccReconstruction: MCPhysics as input to make the skim + save SiTrack…

### DIFF
--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -839,7 +839,7 @@
     <!-- FIXME:Check if we really want to keep those -->
     <parameter name="KeepDaughtersPDG" type="IntVec">22 111 310 13 211 321 3120 </parameter>
     <!--Name of the MCParticle input collection-->
-    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCPhysicsParticles </parameter>
     <!--Name of the skimmed MCParticle  output collection - not created if empty()-->
     <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmed </parameter>
     <!--Name of the MCTruthClusterLink output collection-->
@@ -1165,6 +1165,7 @@
       MCPhysicsParticles
       RecoMCTruthLink
       SiTracks
+      SiTracks_Refitted
       PandoraClusters
       PandoraPFOs
       SelectedPandoraPFOs

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -8,6 +8,10 @@
     <processor name="InitDD4hep"/>
     <processor name="Config" />
 
+    <if condition="Config.OverlayFalse">
+      <processor name="OverlayFalse"/>
+    </if>
+
     <if condition="Config.Overlay91GeV">
       <processor name="Overlay91GeV"/>
     </if>
@@ -81,10 +85,15 @@
   </processor>
 
   <processor name="Config" type="CLICRecoConfig" >
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
     <!--Which option to use for overlay: False, 91GeV, 365GeV. Then use, e.g., Config.Overlay91GeV in the condition-->
     <parameter name="Overlay" type="string">False </parameter>
-    <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal-->
+    <!--Possible values and conditions for option Overlay-->
+    <parameter name="OverlayChoices" type="StringVec"> False 91GeV 365GeV </parameter>
+    <!--Which option to use for tracking: Truth, ConformalPlusExtrapolator, Conformal.-->
     <parameter name="Tracking" type="string">Conformal </parameter>
+    <!--Possible values and conditions for option Tracking-->
+    <parameter name="TrackingChoices" type="StringVec"> Truth Conformal </parameter>
   </processor>
 
   <group name="Overlay">

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -100,35 +100,6 @@
     <parameter name="MCParticleCollectionName" type="string">MCParticle </parameter>
     <!--The output MC Particle Collection Name for the physics event-->
     <parameter name="MCPhysicsParticleCollectionName" type="string"> MCPhysicsParticles </parameter>
-    <!--Time difference between bunches in the bunch train in ns-->
-    <parameter name="Delta_t" type="float" value="20"/>
-    <!--Number of bunches in a bunch train-->
-    <parameter name="NBunchtrain" type="int" value="20"/>
-
-    <parameter name="Collection_IntegrationTimes" type="StringVec" >
-      VertexBarrelCollection        380
-      VertexEndcapCollection        380
-
-      InnerTrackerBarrelCollection  380
-      InnerTrackerEndcapCollection  380
-
-      OuterTrackerBarrelCollection  380
-      OuterTrackerEndcapCollection  380
-
-      ECalBarrelCollection          380
-      ECalEndcapCollection          380
-      ECalPlugCollection            380
-
-      HCalBarrelCollection          380
-      HCalEndcapCollection          380
-      HCalRingCollection            380
-
-      YokeBarrelCollection          380
-      YokeEndcapCollection          380
-
-      LumiCalCollection             380
-      BeamCalCollection             380
-    </parameter>
     <!--Number of the Bunch crossing of the physics event-->
     <parameter name="PhysicsBX" type="int" value="1"/>
     <!--Draw random number of Events to overlay from Poisson distribution with  mean value NumberBackground-->
@@ -141,13 +112,77 @@
       pairs_Z_sim.slcio
     </parameter>
 
-      <processor name="Overlay91GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="1."/>
-      </processor>
+    <processor name="OverlayFalse" type="OverlayTimingGeneric">
+      <parameter name="BackgroundFileNames" type="StringVec"> </parameter>
+      <parameter name="NBunchtrain" type="int" value="0"/>
+      <parameter name="NumberBackground" type="float" value="0."/>
+    </processor>
 
-      <processor name="Overlay365GeV" type="OverlayTimingGeneric">
-        <parameter name="NumberBackground" type="float" value="1."/>
-      </processor>
+    <processor name="Overlay91GeV" type="OverlayTimingGeneric">
+      <!--Time difference between bunches in the bunch train in ns (19.6ns in reality)-->
+      <parameter name="Delta_t" type="float" value="20"/>
+      <!--Number of bunches in a bunch train-->
+      <parameter name="NBunchtrain" type="int" value="20"/>
+      <!--Integration time per subdetector: at the moment 400ns (from ALICE?) - 20ns (Physics is at 1st BX) -->
+      <parameter name="Collection_IntegrationTimes" type="StringVec" >
+	VertexBarrelCollection        380
+	VertexEndcapCollection        380
+
+	InnerTrackerBarrelCollection  380
+	InnerTrackerEndcapCollection  380
+
+	OuterTrackerBarrelCollection  380
+	OuterTrackerEndcapCollection  380
+
+	ECalBarrelCollection          380
+	ECalEndcapCollection          380
+	ECalPlugCollection            380
+
+	HCalBarrelCollection          380
+	HCalEndcapCollection          380
+	HCalRingCollection            380
+
+	YokeBarrelCollection          380
+	YokeEndcapCollection          380
+
+	LumiCalCollection             380
+	BeamCalCollection             380
+      </parameter>
+      <parameter name="NumberBackground" type="float" value="1."/>
+    </processor>
+
+    <processor name="Overlay365GeV" type="OverlayTimingGeneric">
+      <!--Time difference between bunches in the bunch train in ns-->
+      <parameter name="Delta_t" type="float" value="3396"/>
+      <!--Number of bunches in a bunch train-->
+      <parameter name="NBunchtrain" type="int" value="3"/>
+      <!--Integration time per subdetector: at the moment 10us (from ALICE?) - 3369ns (Physics is at 1st BX) -->
+      <parameter name="Collection_IntegrationTimes" type="StringVec" >
+	VertexBarrelCollection        6631
+	VertexEndcapCollection        6631
+
+	InnerTrackerBarrelCollection  6631
+	InnerTrackerEndcapCollection  6631
+
+	OuterTrackerBarrelCollection  6631
+	OuterTrackerEndcapCollection  6631
+
+	ECalBarrelCollection          6631
+	ECalEndcapCollection          6631
+	ECalPlugCollection            6631
+
+	HCalBarrelCollection          6631
+	HCalEndcapCollection          6631
+	HCalRingCollection            6631
+
+	YokeBarrelCollection          6631
+	YokeEndcapCollection          6631
+
+	LumiCalCollection             6631
+	BeamCalCollection             6631
+      </parameter>
+      <parameter name="NumberBackground" type="float" value="1."/>
+    </processor>
   </group>
 
   <processor name="VXDBarrelDigitiser" type="DDPlanarDigiProcessor">

--- a/examples/fccReconstruction.xml
+++ b/examples/fccReconstruction.xml
@@ -100,6 +100,35 @@
     <parameter name="MCParticleCollectionName" type="string">MCParticle </parameter>
     <!--The output MC Particle Collection Name for the physics event-->
     <parameter name="MCPhysicsParticleCollectionName" type="string"> MCPhysicsParticles </parameter>
+    <!--Time difference between bunches in the bunch train in ns-->
+    <parameter name="Delta_t" type="float" value="20"/>
+    <!--Number of bunches in a bunch train-->
+    <parameter name="NBunchtrain" type="int" value="20"/>
+
+    <parameter name="Collection_IntegrationTimes" type="StringVec" >
+      VertexBarrelCollection        380
+      VertexEndcapCollection        380
+
+      InnerTrackerBarrelCollection  380
+      InnerTrackerEndcapCollection  380
+
+      OuterTrackerBarrelCollection  380
+      OuterTrackerEndcapCollection  380
+
+      ECalBarrelCollection          380
+      ECalEndcapCollection          380
+      ECalPlugCollection            380
+
+      HCalBarrelCollection          380
+      HCalEndcapCollection          380
+      HCalRingCollection            380
+
+      YokeBarrelCollection          380
+      YokeEndcapCollection          380
+
+      LumiCalCollection             380
+      BeamCalCollection             380
+    </parameter>
     <!--Number of the Bunch crossing of the physics event-->
     <parameter name="PhysicsBX" type="int" value="1"/>
     <!--Draw random number of Events to overlay from Poisson distribution with  mean value NumberBackground-->
@@ -119,35 +148,6 @@
     </processor>
 
     <processor name="Overlay91GeV" type="OverlayTimingGeneric">
-      <!--Time difference between bunches in the bunch train in ns (19.6ns in reality)-->
-      <parameter name="Delta_t" type="float" value="20"/>
-      <!--Number of bunches in a bunch train-->
-      <parameter name="NBunchtrain" type="int" value="20"/>
-      <!--Integration time per subdetector: at the moment 400ns (from ALICE?) - 20ns (Physics is at 1st BX) -->
-      <parameter name="Collection_IntegrationTimes" type="StringVec" >
-	VertexBarrelCollection        380
-	VertexEndcapCollection        380
-
-	InnerTrackerBarrelCollection  380
-	InnerTrackerEndcapCollection  380
-
-	OuterTrackerBarrelCollection  380
-	OuterTrackerEndcapCollection  380
-
-	ECalBarrelCollection          380
-	ECalEndcapCollection          380
-	ECalPlugCollection            380
-
-	HCalBarrelCollection          380
-	HCalEndcapCollection          380
-	HCalRingCollection            380
-
-	YokeBarrelCollection          380
-	YokeEndcapCollection          380
-
-	LumiCalCollection             380
-	BeamCalCollection             380
-      </parameter>
       <parameter name="NumberBackground" type="float" value="1."/>
     </processor>
 


### PR DESCRIPTION
…s_Refitted in the DST + fixed setup for Overlay group



BEGINRELEASENOTES
- Updates in the fccReconstruction.xml:
- MCPhysicsParticles (instead of MCParticle) given as input to the RecoMCTruthLinker to make the MCParticlesSkimmed
- SiTracks_Refitted added to the output collections in the DST
- fixed setup for Overlay group
ENDRELEASENOTES