### PR TITLE
Steering files: added pt cut to enable extendHighPt

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -427,32 +427,32 @@
     <parameter name="Steps" type="StringVec"> 
       [VXDBarrel]
       @Collections : VXDTrackerHits
-      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker
       @Functions : CombineCollections, BuildNewTracks
       [VXDEncap]
       @Collections : VXDEndcapTrackerHits
-      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker
       @Functions : CombineCollections, ExtendTracks
       [LowerCellAngle1]
       @Collections : VXDTrackerHits, VXDEndcapTrackerHits
-      @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+      @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : CombineCollections, BuildNewTracks
       [LowerCellAngle2]
       @Collections :
-      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
+      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : BuildNewTracks, SortTracks
       [Tracker]
       @Collections : ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
+      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 1.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : CombineCollections, ExtendTracks
       [Displaced]
       @Collections : VXDTrackerHits, VXDEndcapTrackerHits, ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015;
+      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; HighPTCut: 10.0;
       @Flags : OnlyZSchi2cut, RadialSearch
       @Functions : CombineCollections, BuildNewTracks
     </parameter>

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -360,32 +360,32 @@
     <parameter name="Steps" type="StringVec"> 
       [VXDBarrel]
       @Collections : VXDTrackerHits
-      @Parameters : MaxCellAngle : 0.01; MaxCellAngleRZ : 0.01; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03;
+      @Parameters : MaxCellAngle : 0.01; MaxCellAngleRZ : 0.01; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker
       @Functions : CombineCollections, BuildNewTracks
       [VXDEncap]
       @Collections : VXDEndcapTrackerHits
-      @Parameters : MaxCellAngle : 0.01; MaxCellAngleRZ : 0.01; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03;
+      @Parameters : MaxCellAngle : 0.01; MaxCellAngleRZ : 0.01; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker
       @Functions : CombineCollections, ExtendTracks
       [LowerCellAngle1]
       @Collections : VXDTrackerHits, VXDEndcapTrackerHits
-      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03;
+      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.03; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : CombineCollections, BuildNewTracks
       [LowerCellAngle2]
       @Collections :
-      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.03;
+      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.03; HighPTCut: 10.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : BuildNewTracks, SortTracks
       [Tracker]
       @Collections : ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.03;
+      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.03; HighPTCut: 1.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : CombineCollections, ExtendTracks
       [Displaced]
       @Collections : VXDTrackerHits, VXDEndcapTrackerHits, ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015;
+      @Parameters : MaxCellAngle : 0.1; MaxCellAngleRZ : 0.1; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; HighPTCut: 10.0;
       @Flags : OnlyZSchi2cut, RadialSearch
       @Functions : CombineCollections, BuildNewTracks
     </parameter>


### PR DESCRIPTION
BEGINRELEASENOTES
- ConformalTracking: Set pT threshold to run extendHighPt as introduced in iLCSoft/ConformalTracking#42
  - Added to both clic and fccee steering files

ENDRELEASENOTES