### PR TITLE
Use trackHits to compute MC hits in tree

### DIFF
--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -709,7 +709,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
       m_vertexR = mcVertexR;
       m_reconstructed = reconstructed;
       m_nHits = particleTrackHits[particle];
-      m_nHitsMC = uniqueHits;
+      m_nHitsMC = trackHits.size();
       m_distClosestMCPart = minDR;
       m_closeTracks = nCloseTrk;
       m_simplifiedTree->Fill();


### PR DESCRIPTION

BEGINRELEASENOTES
- In the tree the nHitsMC must be the number of hits that are reconstructed and that belong to the same particle. 

ENDRELEASENOTES