### PR TITLE
ClicRecoConfig: add Not + option with negative condition

### DIFF
--- a/source/Conditions/src/CLICRecoConfig.cc
+++ b/source/Conditions/src/CLICRecoConfig.cc
@@ -39,6 +39,7 @@ void CLICRecoConfig::init() {
     checkOptions(choice, choices);
     for (auto& option: choices ) {
       m_options[name+option] = (choice == option);
+      m_options[name + "Not" + option] = (choice != option);
     }
   }
 


### PR DESCRIPTION
Allows using negative condition like 'Config.OverlayNotFalse'



BEGINRELEASENOTES
-  ClicRecoConfig: add Not + option with negative condition,  'Config.OverlayNotFalse' which would be true if the choice is not False (3TeV, etc

ENDRELEASENOTES