### PR TITLE
Add refjets collection to DST outputs

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1730,6 +1730,10 @@
       BeamCalRecoParticles
       MergedRecoParticles
       MergedClusters
+      RefJets
+      RefJets_rel
+      RefJets_vtx
+      RefJets_vtx_RP
       buVx
       buVx_res
       buVx_RP

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1431,6 +1431,10 @@
       SelectedPandoraPFOs
       LooseSelectedPandoraPFOs
       TightSelectedPandoraPFOs
+      RefJets
+      RefJets_rel
+      RefJets_vtx
+      RefJets_vtx_RP
       buVx
       buVx_res
       buVx_RP


### PR DESCRIPTION

BEGINRELEASENOTES
- ClicReconstruction: add RefJets collections explicitely to DST Output, RefJets ReconstructedParticle collection was missing, and is needed for FlavourTagging NTuple Maker

- FccReconstruction: add RefJets collections explicitely to DST Output, RefJets ReconstructedParticle collection was missing, and is needed for FlavourTagging NTuple Maker

ENDRELEASENOTES