### PR TITLE
Update LCFIPLus parameters and collection names

### DIFF
--- a/Flavour_tagging/vtx_makentp.xml
+++ b/Flavour_tagging/vtx_makentp.xml
@@ -9,9 +9,9 @@
 <!-- ========== Pre-JetClustering with FastJet to fight gg->hadrons background ========== -->
 <Xprocessor name="MyFastJetProcessor"/>
 <!-- ========== Vertex Finder =========================================================== -->
-<processor name="VertexFinder"/>
+<Xprocessor name="VertexFinder"/>
 <!-- ========== Jet Clustering and Vertex Refiner ======================================= -->
-<processor name="jets"/>
+<Xprocessor name="jets"/>
 <!-- ========== Make Ntuples for the training  ========================================== -->
 <processor name="MakeNtuple"/>
 <!-- ========== LCIO Output  ============================================================ -->
@@ -116,6 +116,7 @@ input_file.slcio
 <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
 
 <!-- jet clustering parameters -->
+<parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" /> <!-- Needed for post 00.06.09 -->
 <parameter name="JetClustering.InputVertexCollectionName" type="string" value="BuildUpVertices" /> <!-- vertex collections to be used in JC -->
 <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="VertexJets" /> <!-- output collection name, may be multiple -->
 <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->

--- a/Flavour_tagging/vtx_makentp.xml
+++ b/Flavour_tagging/vtx_makentp.xml
@@ -3,6 +3,9 @@
 
 
 <execute>
+
+<processor name="InitDD4hep"/>
+
 <!-- ========== Pre-JetClustering with FastJet to fight gg->hadrons background ========== -->
 <Xprocessor name="MyFastJetProcessor"/>
 <!-- ========== Vertex Finder =========================================================== -->
@@ -25,6 +28,15 @@ input_file.slcio
 <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING  </parameter>
 <parameter name="RandomSeed" value="1234567890" />
 </global>
+
+<processor name="InitDD4hep" type="InitializeDD4hep">
+  <!--InitializeDD4hep reads a compact xml file and initializes the DD4hep::LCDD object-->
+  <!--Name of the DD4hep compact xml file to load-->
+  <parameter name="EncodingStringParameter"> GlobalTrackerReadoutID </parameter>
+  <parameter name="DD4hepXMLFile" type="string">
+    /cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
+  </parameter>
+</processor>
 
 <!-- ========== Jet clustering for gg->hadrons removal ================================== -->
 <processor name="MyFastJetProcessor" type="FastJetProcessor">

--- a/Flavour_tagging/vtx_makentp.xml
+++ b/Flavour_tagging/vtx_makentp.xml
@@ -51,9 +51,9 @@ input_file.slcio
     <parameter name="UseMCP" type="int" value="0" /> <!-- MC info not used -->
     <parameter name="MCPCollection" type="string" value="MCParticle" />
     <parameter name="MCPFORelation" type="string" value="RecoMCTruthLink" />
-    <parameter name="PrimaryVertexCollectionName" type="string" value="pVx" />
-    <parameter name="BuildUpVertexCollectionName" type="string" value="buVx" />
-    <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0" />
+    <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
+    <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertices" />
+    <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
     <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
     <parameter name="BeamSizeX" type="float" value="639.E-6"/> <!-- XYZ need to be checked and corrected to CLIC values -->
     <parameter name="BeamSizeY" type="float" value="5.7E-6"/>
@@ -104,8 +104,8 @@ input_file.slcio
 <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
 
 <!-- jet clustering parameters -->
-<parameter name="JetClustering.InputVertexCollectionName" type="string" value="buVx" /> <!-- vertex collections to be used in JC -->
-<parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="Vx" /> <!-- output collection name, may be multiple -->
+<parameter name="JetClustering.InputVertexCollectionName" type="string" value="BuildUpVertices" /> <!-- vertex collections to be used in JC -->
+<parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="VertexJets" /> <!-- output collection name, may be multiple -->
 <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->
 
 <parameter name="JetClustering.YCut" type="doubleVec" value="0." /> <!-- specify 0 if not used -->
@@ -120,12 +120,12 @@ input_file.slcio
 
 
 <!-- vertex refiner parameters -->
-<parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="Vx" />
-<parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
-<parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="pVx" />
-<parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="buVx" />
-<parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="buVx_V0" />
-<parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefVx" />
+<parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />
+<parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefinedVertexJets" />
+<parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
+<parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />
+<parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
+<parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefinedVertexJets" />
 <parameter name="JetVertexRefiner.MinPosSingle" type="double" value="0.3" />
 <parameter name="JetVertexRefiner.MaxPosSingle" type="double" value="30." />
 <parameter name="JetVertexRefiner.MinEnergySingle" type="double" value="1." />
@@ -153,8 +153,8 @@ input_file.slcio
 <parameter name="TrackHitOrdering" type="int" value="2"/> <!-- Track hit ordering: 0=ILD-LOI (default), 1=ILD-DBD, 2=CLICdet -->
 <parameter name="PrintEventNumber" type="int" value="1"/> <!-- 0 for not printing event number, n for printing every n events -->
 <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
-<parameter name="PrimaryVertexCollectionName" type="string" value="pVx" />
-<parameter name="FlavorTag.JetCollectionName" type="string" value="RefJets" />
+<parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
+<parameter name="FlavorTag.JetCollectionName" type="string" value="RefinedVertexJets" />
 <parameter name="MakeNtuple.AuxiliaryInfo" type="int" value="-1" />
 <parameter name="FlavorTag.D0ProbFileName" type="string" value="vtxprob/d0prob_zpole.root"/>
 <parameter name="FlavorTag.Z0ProbFileName" type="string" value="vtxprob/z0prob_zpole.root"/>

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -118,6 +118,18 @@ ADD_TEST( NAME t_${test_name}
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
 
+SET( test_name "test_${CLIC_DETECTOR_MODEL}_vtx_makentp" )
+ADD_TEST( NAME t_${test_name}
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/bin/MarlinTests.sh
+  ${CMAKE_INSTALL_PREFIX}/lib/libClicPerformance.so  Marlin
+  --InitDD4hep.DD4hepXMLFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
+  --global.LCIOInputFiles=../clicConfig/reco_conformal_${CLIC_DETECTOR_MODEL}_dst.slcio
+  --global.MaxRecordNumber=2
+  vtx_makentp.xml
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../Flavour_tagging/
+  )
+SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;\\[ ERROR;Error" )
+
 SET( test_name "test_${CLIC_DETECTOR_MODEL}_reco_real_overlay" )
 ADD_TEST( NAME t_${test_name}
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/bin/MarlinTests.sh

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1607,6 +1607,7 @@
     <parameter name="BuildUpVertex.TrackMaxD0Err" type="double" value="0.1" />
     <parameter name="BuildUpVertex.TrackMaxZ0Err" type="double" value="0.1" />
     <parameter name="BuildUpVertex.TrackMinTpcHits" type="int" value="1" />
+    <parameter name="BuildUpVertex.TrackMinTpcHitsMinPt" type="double" value="999999" /><!--FIXME-->
     <parameter name="BuildUpVertex.TrackMinFtdHits" type="int" value="1" />
     <parameter name="BuildUpVertex.TrackMinVxdHits" type="int" value="1" />
     <parameter name="BuildUpVertex.TrackMinVxdFtdHits" type="int" value="1" />

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1662,7 +1662,7 @@
     <parameter name="JetClustering.JetAlgorithm" type="string" value="Durham"/> 
     <!-- vertex refiner parameters -->
     <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />
-    <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
+    <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefinedVertexJets" />
     <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
     <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />
     <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
@@ -1730,10 +1730,10 @@
       BeamCalRecoParticles
       MergedRecoParticles
       MergedClusters
-      RefJets
-      RefJets_rel
-      RefJets_vtx
-      RefJets_vtx_RP
+      RefinedVertexJets
+      RefinedVertexJets_rel
+      RefinedVertexJets_vtx
+      RefinedVertexJets_vtx_RP
       BuildUpVertices
       BuildUpVertices_res
       BuildUpVertices_RP

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1649,7 +1649,7 @@
     <!-- jet clustering parameters -->
     <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" /> <!-- Needed for post 00.06.09 -->
     <parameter name="JetClustering.InputVertexCollectionName" type="string" value="BuildUpVertices" /> <!-- vertex collections to be used in JC -->
-    <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="Vx" /> <!-- output collection name, may be multiple -->
+    <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="VertexJets" /> <!-- output collection name, may be multiple -->
     <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->
     <parameter name="JetClustering.YCut" type="doubleVec" value="0." /> <!-- specify 0 if not used -->
     <parameter name="JetClustering.UseMuonID" type="int" value="1" /> <!-- jet-muon ID for jet clustering -->
@@ -1661,7 +1661,7 @@
     <parameter name="JetClustering.YAddedForJetLeptonLepton" type="double" value="100"/> <!-- add penalty for combining leptons -->
     <parameter name="JetClustering.JetAlgorithm" type="string" value="Durham"/> 
     <!-- vertex refiner parameters -->
-    <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="Vx" />
+    <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />
     <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
     <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
     <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1590,7 +1590,7 @@
     <parameter name="PrimaryVertexFinder.BeamspotSmearing" type="boolean" value="false" />
     <parameter name="PrimaryVertexFinder.TrackMaxD0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
-    <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" />
+    <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" /><!-- obsolete? -->
     <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
     <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
     <!-- irrelevant because of TrackMinVtxFtdHits = 1 -->

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1593,6 +1593,12 @@
     <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" />
     <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
     <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
+    <!-- irrelevant because of TrackMinVtxFtdHits = 1 -->
+    <parameter name="PrimaryVertexFinder.TrackMinFtdHits" type="int" value="999999" />
+    <parameter name="PrimaryVertexFinder.TrackMinVxdHits" type="double" value="999999" />
+    <!-- No tracks with hits only in the main silicon tracker -->
+    <parameter name="PrimaryVertexFinder.TrackMinTpcHits" type="int" value="999999" />
+    <parameter name="PrimaryVertexFinder.TrackMinTpcHitsMinPt" type="double" value="999999" />
 
     <!-- parameters for secondary vertex finder -->
     <parameter name="BuildUpVertex.TrackMaxD0" type="double" value="10." />

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1670,7 +1670,24 @@
     <parameter name="JetClustering.YAddedForJetVertexVertex" type="double" value="100"/> <!-- add penalty for combining vertices -->
     <parameter name="JetClustering.YAddedForJetLeptonVertex" type="double" value="100"/> <!-- add penalty for combining lepton and vertex -->
     <parameter name="JetClustering.YAddedForJetLeptonLepton" type="double" value="100"/> <!-- add penalty for combining leptons -->
-    <parameter name="JetClustering.JetAlgorithm" type="string" value="Durham"/> 
+
+    <parameter name="JetClustering.JetAlgorithm" type="string" value="ValenciaVertex" /> <!-- jet algorithm -->
+    <parameter name="JetClustering.UseBeamJets" type="int" value="1" /> <!-- beam jet rejection -->
+    <parameter name="JetClustering.AlphaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.BetaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.GammaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.RParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.OutputJetStoresVertex" type="int" value="0" />
+    <parameter name="JetClustering.YAddedForJetVertexLepton" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDExternal" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDMinimumEnergy" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumEnergy" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDMinimumD0Significance" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumZ0Significance" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMaximum3DImpactParameter" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumProbability" type="double" value="0.5" />
+    <parameter name="JetClustering.MaxNumberOfJetsForYThreshold" type="int" value="10" />
+
     <!-- vertex refiner parameters -->
     <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />
     <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefinedVertexJets" />

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1587,6 +1587,7 @@
     <parameter name="BeamSizeY" type="float" value="1.0E-6"/>
     <parameter name="BeamSizeZ" type="float" value="44E-3"/>
     <!-- parameters for primary vertex finder -->
+    <parameter name="PrimaryVertexFinder.BeamspotSmearing" type="boolean" value="false" />
     <parameter name="PrimaryVertexFinder.TrackMaxD0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" />

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1618,8 +1618,8 @@
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="PFOsFromJets" />
       <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
-      <parameter name="BuildUpVertexCollectionName" type="string" value="buVx" />
-      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0" />
+      <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertices" />
+      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">1 </parameter>
     </processor>  
 
@@ -1628,8 +1628,8 @@
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="TightSelectedPandoraPFOs" />
       <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices_res" />
-      <parameter name="BuildUpVertexCollectionName" type="string" value="buVx_res" />
-      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0_res" />
+      <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertices_res" />
+      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertices_V0_res" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">0 </parameter>
     </processor>
   </group>
@@ -1648,7 +1648,7 @@
     <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
     <!-- jet clustering parameters -->
     <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" /> <!-- Needed for post 00.06.09 -->
-    <parameter name="JetClustering.InputVertexCollectionName" type="string" value="buVx" /> <!-- vertex collections to be used in JC -->
+    <parameter name="JetClustering.InputVertexCollectionName" type="string" value="BuildUpVertices" /> <!-- vertex collections to be used in JC -->
     <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="Vx" /> <!-- output collection name, may be multiple -->
     <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->
     <parameter name="JetClustering.YCut" type="doubleVec" value="0." /> <!-- specify 0 if not used -->
@@ -1664,8 +1664,8 @@
     <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="Vx" />
     <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
     <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
-    <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="buVx" />
-    <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="buVx_V0" />
+    <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />
+    <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
     <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefVx" />
     <parameter name="JetVertexRefiner.MinPosSingle" type="double" value="0.3" />
     <parameter name="JetVertexRefiner.MaxPosSingle" type="double" value="30." />
@@ -1734,14 +1734,14 @@
       RefJets_rel
       RefJets_vtx
       RefJets_vtx_RP
-      buVx
-      buVx_res
-      buVx_RP
-      buVX_res_RP
-      buVx_V0
-      buVX_V0_res
-      buVx_V0_RP
-      buVX_V0_res_RP
+      BuildUpVertices
+      BuildUpVertices_res
+      BuildUpVertices_RP
+      BuildUpVertices_res_RP
+      BuildUpVertices_V0
+      BuildUpVertices_V0_res
+      BuildUpVertices_V0_RP
+      BuildUpVertices_V0_res_RP
       PrimaryVertices
       PrimaryVertices_res
       PrimaryVertices_RP

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1617,7 +1617,7 @@
     <processor name="VertexFinder" type="LcfiplusProcessor">
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="PFOsFromJets" />
-      <parameter name="PrimaryVertexCollectionName" type="string" value="pVx" />
+      <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
       <parameter name="BuildUpVertexCollectionName" type="string" value="buVx" />
       <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">1 </parameter>
@@ -1627,7 +1627,7 @@
     <processor name="VertexFinderUnconstrained" type="LcfiplusProcessor">
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="TightSelectedPandoraPFOs" />
-      <parameter name="PrimaryVertexCollectionName" type="string" value="pVx_res" />
+      <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices_res" />
       <parameter name="BuildUpVertexCollectionName" type="string" value="buVx_res" />
       <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0_res" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">0 </parameter>
@@ -1647,7 +1647,7 @@
     <parameter name="PrintEventNumber" type="int" value="1"/> <!-- 0 for not printing event number, n for printing every n events -->
     <parameter name="MagneticField" type="float" value="4.0"/> <!-- ILC and CLIC detectors have different values -->
     <!-- jet clustering parameters -->
-    <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="pVx" /> <!-- Needed for post 00.06.09 -->
+    <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" /> <!-- Needed for post 00.06.09 -->
     <parameter name="JetClustering.InputVertexCollectionName" type="string" value="buVx" /> <!-- vertex collections to be used in JC -->
     <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="Vx" /> <!-- output collection name, may be multiple -->
     <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->
@@ -1663,7 +1663,7 @@
     <!-- vertex refiner parameters -->
     <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="Vx" />
     <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
-    <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="pVx" />
+    <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
     <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="buVx" />
     <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="buVx_V0" />
     <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefVx" />
@@ -1742,10 +1742,10 @@
       buVX_V0_res
       buVx_V0_RP
       buVX_V0_res_RP
-      pVx
-      pVx_res
-      pVx_RP
-      pVx_res_RP
+      PrimaryVertices
+      PrimaryVertices_res
+      PrimaryVertices_RP
+      PrimaryVertices_res_RP
       RefVx
       RefVx_RP
     </parameter>

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1612,6 +1612,9 @@
     <parameter name="BuildUpVertex.AssocIPTracksMinDist" type="double" value="0." />
     <parameter name="BuildUpVertex.AssocIPTracksChi2RatioSecToPri" type="double" value="2.0" />
     <parameter name="BuildUpVertex.UseV0Selection" type="int" value="1" />
+    <!-- Disable AVF -->
+    <parameter name="BuildUpVertex.UseAVF" type="boolean" value="false" />
+    <parameter name="BuildUpVertex.AVFTemperature" type="double" value="5.0" />
 
     <!-- Primary and Secondary vertex finder ================================================ -->
     <processor name="VertexFinder" type="LcfiplusProcessor">

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -1666,7 +1666,7 @@
     <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
     <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />
     <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
-    <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefVx" />
+    <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefinedVertices" />
     <parameter name="JetVertexRefiner.MinPosSingle" type="double" value="0.3" />
     <parameter name="JetVertexRefiner.MaxPosSingle" type="double" value="30." />
     <parameter name="JetVertexRefiner.MinEnergySingle" type="double" value="1." />
@@ -1746,8 +1746,8 @@
       PrimaryVertices_res
       PrimaryVertices_RP
       PrimaryVertices_res_RP
-      RefVx
-      RefVx_RP
+      RefinedVertices
+      RefinedVertices_RP
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
     <parameter name="Verbosity" type="string">WARNING </parameter>

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1377,8 +1377,23 @@
     <parameter name="JetClustering.YAddedForJetVertexVertex" type="double" value="100"/> <!-- add penalty for combining vertices -->
     <parameter name="JetClustering.YAddedForJetLeptonVertex" type="double" value="100"/> <!-- add penalty for combining lepton and vertex -->
     <parameter name="JetClustering.YAddedForJetLeptonLepton" type="double" value="100"/> <!-- add penalty for combining leptons -->
-    <parameter name="JetClustering.JetAlgorithm" type="string" value="Durham"/> 
 
+    <parameter name="JetClustering.JetAlgorithm" type="string" value="ValenciaVertex" /> <!-- jet algorithm -->
+    <parameter name="JetClustering.UseBeamJets" type="int" value="1" /> <!-- beam jet rejection -->
+    <parameter name="JetClustering.AlphaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.BetaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.GammaParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.RParameter" type="double" value="1.0" />
+    <parameter name="JetClustering.OutputJetStoresVertex" type="int" value="0" />
+    <parameter name="JetClustering.YAddedForJetVertexLepton" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDExternal" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDMinimumEnergy" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumEnergy" type="int" value="0" />
+    <parameter name="JetClustering.MuonIDMinimumD0Significance" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumZ0Significance" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMaximum3DImpactParameter" type="double" value="5.0" />
+    <parameter name="JetClustering.MuonIDMinimumProbability" type="double" value="0.5" />
+    <parameter name="JetClustering.MaxNumberOfJetsForYThreshold" type="int" value="10" />
 
     <!-- vertex refiner parameters -->
     <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1321,6 +1321,9 @@
     <parameter name="BuildUpVertex.AssocIPTracksMinDist" type="double" value="0." />
     <parameter name="BuildUpVertex.AssocIPTracksChi2RatioSecToPri" type="double" value="2.0" />
     <parameter name="BuildUpVertex.UseV0Selection" type="int" value="1" />
+    <!-- Disable AVF -->
+    <parameter name="BuildUpVertex.UseAVF" type="boolean" value="false" />
+    <parameter name="BuildUpVertex.AVFTemperature" type="double" value="5.0" />
 
     <!-- Primary and Secondary vertex finder ================================================ -->
     <processor name="VertexFinder" type="LcfiplusProcessor">

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1291,7 +1291,7 @@
     <parameter name="PrimaryVertexFinder.BeamspotSmearing" type="boolean" value="false" />
     <parameter name="PrimaryVertexFinder.TrackMaxD0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
-    <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" />
+    <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" /><!-- obsolete? -->
     <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
     <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1294,6 +1294,12 @@
     <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" /><!-- obsolete? -->
     <parameter name="PrimaryVertexFinder.TrackMinVtxFtdHits" type="int" value="1" />
     <parameter name="PrimaryVertexFinder.Chi2Threshold" type="double" value="25." />
+    <!-- irrelevant because of TrackMinVtxFtdHits = 1 -->
+    <parameter name="PrimaryVertexFinder.TrackMinFtdHits" type="int" value="999999" />
+    <parameter name="PrimaryVertexFinder.TrackMinVxdHits" type="double" value="999999" />
+    <!-- No tracks with hits only in the main silicon tracker -->
+    <parameter name="PrimaryVertexFinder.TrackMinTpcHits" type="int" value="999999" />
+    <parameter name="PrimaryVertexFinder.TrackMinTpcHitsMinPt" type="double" value="999999" />
 
     <!-- parameters for secondary vertex finder -->
     <parameter name="BuildUpVertex.TrackMaxD0" type="double" value="10." />

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1329,9 +1329,9 @@
     <processor name="VertexFinder" type="LcfiplusProcessor">
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="PFOsFromJets" />
-      <parameter name="PrimaryVertexCollectionName" type="string" value="pVx" />
-      <parameter name="BuildUpVertexCollectionName" type="string" value="buVx" />
-      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0" />
+      <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
+      <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertices" />
+      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">1 </parameter>
     </processor>
 
@@ -1339,9 +1339,9 @@
     <processor name="VertexFinderUnconstrained" type="LcfiplusProcessor">
       <!-- run primary and secondary vertex finders -->
       <parameter name="PFOCollection" type="string" value="TightSelectedPandoraPFOs" />
-      <parameter name="PrimaryVertexCollectionName" type="string" value="pVx_res" />
-      <parameter name="BuildUpVertexCollectionName" type="string" value="buVx_res" />
-      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="buVx_V0_res" />
+      <parameter name="PrimaryVertexCollectionName" type="string" value="PrimaryVertices_res" />
+      <parameter name="BuildUpVertexCollectionName" type="string" value="BuildUpVertices_res" />
+      <parameter name="BuildUpVertex.V0VertexCollectionName" type="string" value="BuildUpVertices_V0_res" />
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">0 </parameter>
     </processor>
 
@@ -1364,9 +1364,9 @@
     <parameter name="MagneticField" type="float" value="2.0"/> <!-- ILC and CLIC detectors have different values -->
 
     <!-- jet clustering parameters -->
-    <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="pVx"/> <!-- Needed for post 00.06.09-->
-    <parameter name="JetClustering.InputVertexCollectionName" type="string" value="buVx" /> <!-- vertex collections to be used in JC -->
-    <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="Vx" /> <!-- output collection name, may be multiple -->
+    <parameter name="JetClustering.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" /> <!-- Needed for post 00.06.09 -->
+    <parameter name="JetClustering.InputVertexCollectionName" type="string" value="BuildUpVertices" /> <!-- vertex collections to be used in JC -->
+    <parameter name="JetClustering.OutputJetCollectionName" type="stringVec" value="VertexJets" /> <!-- output collection name, may be multiple -->
     <parameter name="JetClustering.NJetsRequested" type="intVec" value="2" /> <!-- Multiple NJets can be specified -->
 
     <parameter name="JetClustering.YCut" type="doubleVec" value="0." /> <!-- specify 0 if not used -->
@@ -1381,12 +1381,12 @@
 
 
     <!-- vertex refiner parameters -->
-    <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="Vx" />
-    <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefJets" />
-    <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="pVx" />
-    <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="buVx" />
-    <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="buVx_V0" />
-    <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefVx" />
+    <parameter name="JetVertexRefiner.InputJetCollectionName" type="string" value="VertexJets" />
+    <parameter name="JetVertexRefiner.OutputJetCollectionName" type="string" value="RefinedVertexJets" />
+    <parameter name="JetVertexRefiner.PrimaryVertexCollectionName" type="string" value="PrimaryVertices" />
+    <parameter name="JetVertexRefiner.InputVertexCollectionName" type="string" value="BuildUpVertices" />
+    <parameter name="JetVertexRefiner.V0VertexCollectionName" type="string" value="BuildUpVertices_V0" />
+    <parameter name="JetVertexRefiner.OutputVertexCollectionName" type="string" value="RefinedVertices" />
     <parameter name="JetVertexRefiner.MinPosSingle" type="double" value="0.3" />
     <parameter name="JetVertexRefiner.MaxPosSingle" type="double" value="30." />
     <parameter name="JetVertexRefiner.MinEnergySingle" type="double" value="1." />
@@ -1442,24 +1442,24 @@
       SelectedPandoraPFOs
       LooseSelectedPandoraPFOs
       TightSelectedPandoraPFOs
-      RefJets
-      RefJets_rel
-      RefJets_vtx
-      RefJets_vtx_RP
-      buVx
-      buVx_res
-      buVx_RP
-      buVX_res_RP
-      buVx_V0
-      buVX_V0_res
-      buVx_V0_RP
-      buVX_V0_res_RP
-      pVx
-      pVx_res
-      pVx_RP
-      pVx_res_RP
-      RefVx
-      RefVx_RP
+      RefinedVertexJets
+      RefinedVertexJets_rel
+      RefinedVertexJets_vtx
+      RefinedVertexJets_vtx_RP
+      BuildUpVertices
+      BuildUpVertices_res
+      BuildUpVertices_RP
+      BuildUpVertices_res_RP
+      BuildUpVertices_V0
+      BuildUpVertices_V0_res
+      BuildUpVertices_V0_RP
+      BuildUpVertices_V0_res_RP
+      PrimaryVertices
+      PrimaryVertices_res
+      PrimaryVertices_RP
+      PrimaryVertices_res_RP
+      RefinedVertices
+      RefinedVertices_RP
     </parameter>
     <parameter name="LCIOWriteMode" type="string" value="WRITE_NEW"/>
     <parameter name="Verbosity" type="string">WARNING </parameter>

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1288,6 +1288,7 @@
     <parameter name="BeamSizeY" type="float" value="68E-6"/>
     <parameter name="BeamSizeZ" type="float" value="1.97"/>
     <!-- parameters for primary vertex finder -->
+    <parameter name="PrimaryVertexFinder.BeamspotSmearing" type="boolean" value="false" />
     <parameter name="PrimaryVertexFinder.TrackMaxD0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxZ0" type="double" value="20." />
     <parameter name="PrimaryVertexFinder.TrackMaxInnermostHitRadius" type="double" value="61" />

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -1308,6 +1308,7 @@
     <parameter name="BuildUpVertex.TrackMaxD0Err" type="double" value="0.1" />
     <parameter name="BuildUpVertex.TrackMaxZ0Err" type="double" value="0.1" />
     <parameter name="BuildUpVertex.TrackMinTpcHits" type="int" value="1" />
+    <parameter name="BuildUpVertex.TrackMinTpcHitsMinPt" type="double" value="999999" /><!--FIXME-->
     <parameter name="BuildUpVertex.TrackMinFtdHits" type="int" value="1" />
     <parameter name="BuildUpVertex.TrackMinVxdHits" type="int" value="1" />
     <parameter name="BuildUpVertex.TrackMinVxdFtdHits" type="int" value="1" />


### PR DESCRIPTION
BEGINRELEASENOTES
- CLIC/FCC Reconstruction: add default values for lcfiplus processors, fix inconsistencies
- CLIC/FCC Reconstruction: rename collections from vertexing and flavourtagging

ENDRELEASENOTES