### PR TITLE
Add minimum number of cluster for tracks

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -438,6 +438,10 @@
     <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
     <!--Debug hits Collection Name-->
     <parameter name="DebugHits" type="string" lcioOutType="TrackerHitPlane"> DebugHits </parameter>
+    <!--Maximum number of track hits to try the inverted fit-->
+    <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
+    <!--Final minimum number of track clusters-->
+    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
 
     <!--enable debug plots -->
     <parameter name="DebugPlots" type="bool"> false </parameter>

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -353,6 +353,10 @@
     <parameter name="SiTrackCollectionName" type="string" lcioOutType="Track">SiTracksCT </parameter>
     <!--Debug hits Collection Name-->
     <parameter name="DebugHits" type="string" lcioOutType="TrackerHitPlane"> DebugHits </parameter>
+    <!--Maximum number of track hits to try the inverted fit-->
+    <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
+    <!--Final minimum number of track clusters-->
+    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
 
     <!--enable debug plots -->
     <parameter name="DebugPlots" type="bool"> false </parameter>


### PR DESCRIPTION
BEGINRELEASENOTES
- Add final minimum number of track clusters, after KF and set it to 4, needs ilcsoft/conformaltracking#52
- Include maximum number of track hits to try the inverted fit and set it to 0

ENDRELEASENOTES