### PR TITLE
clicReconstruction.xml & fccReconstruction.xml: MinClustersOnTrackAf…

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -533,6 +533,8 @@
     <!--parameter name="Verbosity" type="string"> DEBUG </parameter-->
     <!--if true extrapolation in the forward direction (in-out), otherwise backward (out-in)-->
     <parameter name="extrapolateForward" type="bool"> true </parameter>
+    <!--Final minimum number of track clusters-->
+    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
   </processor>
 
 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -447,6 +447,8 @@
     <!--parameter name="Verbosity" type="string"> DEBUG </parameter-->
     <!--if true extrapolation in the forward direction (in-out), otherwise backward (out-in)-->
     <parameter name="extrapolateForward" type="bool"> true </parameter>
+    <!--Final minimum number of track clusters-->
+    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
   </processor>
 
 


### PR DESCRIPTION
…terFit as processor parameter



BEGINRELEASENOTES
- CLIC FCC Reconstruction: RefitFinal: Added parameter MinClustersOnTrackAfterFit=4 
  - Parameter implementation in iLCSoft/MarlinTrkProcessors#42

ENDRELEASENOTES