### PR TITLE
Explicitly list the rejected PDG codes for simulation

### DIFF
--- a/clicConfig/clic_steer.py
+++ b/clicConfig/clic_steer.py
@@ -223,6 +223,7 @@ SIM.physics.pdgfile = os.path.join( os.environ.get("DD4HEP"), "DDG4/examples/par
 ##     
 SIM.physics.rangecut = 0.7*mm
 
+SIM.physics.rejectPDGs = {1,2,3,4,5,6,21,23,24,25}
 
 ################################################################################
 ## Properties for the random number generator 

--- a/fcceeConfig/fcc_steer.py
+++ b/fcceeConfig/fcc_steer.py
@@ -223,6 +223,7 @@ SIM.physics.pdgfile = os.path.join( os.environ.get("DD4HEP"), "DDG4/examples/par
 ##     
 SIM.physics.rangecut = 0.7*mm
 
+SIM.physics.rejectPDGs = {1,2,3,4,5,6,21,23,24,25}
 
 ################################################################################
 ## Properties for the random number generator 


### PR DESCRIPTION

BEGINRELEASENOTES
- Explicitly list the rejected PDG codes for simulation
  - DD4hep default did not reject Higgs PDG code 25

ENDRELEASENOTES