### PR TITLE
MinClustersOnTrackAfterFit set to 3

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -441,7 +441,7 @@
     <!--Maximum number of track hits to try the inverted fit-->
     <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
     <!--Final minimum number of track clusters-->
-    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
+    <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
 
     <!--enable debug plots -->
     <parameter name="DebugPlots" type="bool"> false </parameter>
@@ -534,7 +534,7 @@
     <!--if true extrapolation in the forward direction (in-out), otherwise backward (out-in)-->
     <parameter name="extrapolateForward" type="bool"> true </parameter>
     <!--Final minimum number of track clusters-->
-    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
+    <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
   </processor>
 
 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -356,7 +356,7 @@
     <!--Maximum number of track hits to try the inverted fit-->
     <parameter name="MaxHitInvertedFit" type="int">0 </parameter>
     <!--Final minimum number of track clusters-->
-    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
+    <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
 
     <!--enable debug plots -->
     <parameter name="DebugPlots" type="bool"> false </parameter>
@@ -448,7 +448,7 @@
     <!--if true extrapolation in the forward direction (in-out), otherwise backward (out-in)-->
     <parameter name="extrapolateForward" type="bool"> true </parameter>
     <!--Final minimum number of track clusters-->
-    <parameter name="MinClustersOnTrackAfterFit" type="int">4 </parameter>
+    <parameter name="MinClustersOnTrackAfterFit" type="int">3 </parameter>
   </processor>
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- CLICReconstruction/FCCReconstruction: ConformalTracking+Refit: 
    - Set the number of minimum hits on a track to 3 after the fit to recover efficiency loss seen in the case of single isolated muons. Previously this was set to 4 to reduce the number of fakes in the complex events which is still acceptable using a threshold at 3 hits.

ENDRELEASENOTES

This can be seen in the following efficiency plots:
[single muons - efficiency]
minimum number of hits on track = 3 : [eff_vs_theta_minNhits3.pdf](https://github.com/iLCSoft/CLICPerformance/files/3277293/eff_vs_theta_minNhits3-eps-converted-to.pdf)
minimum number of hits on track = 4 : [eff_vs_theta_minNhits4.pdf](https://github.com/iLCSoft/CLICPerformance/files/3277294/eff_vs_theta_minNhits4-eps-converted-to.pdf)

[3TeV ttbar w/overlay - fake rate]
minimum number of hits on track = 3 : [fake_vs_pt_minNhits3.pdf](https://github.com/iLCSoft/CLICPerformance/files/3277322/fake_vs_pt_minNhits3-eps-converted-to.pdf)
minimum number of hits on track = 4 : [fake_vs_pt_minNhits4.pdf](https://github.com/iLCSoft/CLICPerformance/files/3277323/fake_vs_pt_minNhits4-eps-converted-to.pdf)



