### PR TITLE
ClicEfficiencyCalculator: fixed is_reco false in trackTree

### DIFF
--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -668,6 +668,7 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
         // m_mcCat.pop_back();
         m_mcCat.push_back(2);
       }else{
+        m_vec_is_reconstructed.push_back(false);
         // m_mcCat.pop_back();
         m_mcCat.push_back(1);
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- ClicEfficiencyCalculator: fixed m_vec_is_reconstructed branch for not reconstructed tracks in trackTree, fixes #116 

ENDRELEASENOTES