### PR TITLE
DDSim: correct the name for the field stepper

### DIFF
--- a/clicConfig/clic_steer.py
+++ b/clicConfig/clic_steer.py
@@ -82,7 +82,7 @@ SIM.field.eps_min = 5e-05*mm
 SIM.field.equation = "Mag_UsualEqRhs"
 SIM.field.largest_step = 10.0*m
 SIM.field.min_chord_step = 0.01*mm
-SIM.field.stepper = "G4ClassicalRK4"
+SIM.field.stepper = "ClassicalRK4"
 
 
 ################################################################################

--- a/fcceeConfig/fcc_steer.py
+++ b/fcceeConfig/fcc_steer.py
@@ -82,7 +82,7 @@ SIM.field.eps_min = 5e-05*mm
 SIM.field.equation = "Mag_UsualEqRhs"
 SIM.field.largest_step = 10.0*m
 SIM.field.min_chord_step = 0.01*mm
-SIM.field.stepper = "G4ClassicalRK4"
+SIM.field.stepper = "ClassicalRK4"
 
 
 ################################################################################


### PR DESCRIPTION



BEGINRELEASENOTES
- DDSim Steer: fix spelling of ClassicalRK4 for magnetic field stepper, this is also the geant4 default
ENDRELEASENOTES