### PR TITLE
DDSim steering files: drop use of deprecated (removed) units file

### DIFF
--- a/clicConfig/clic_steer.py
+++ b/clicConfig/clic_steer.py
@@ -1,7 +1,7 @@
 import os
 
 from DDSim.DD4hepSimulation import DD4hepSimulation
-from SystemOfUnits import mm, GeV, MeV, m, deg
+from g4units import mm, GeV, MeV, m, deg
 SIM = DD4hepSimulation()
 
 ## The compact XML file

--- a/fcceeConfig/fcc_steer.py
+++ b/fcceeConfig/fcc_steer.py
@@ -1,7 +1,7 @@
 import os
 
 from DDSim.DD4hepSimulation import DD4hepSimulation
-from SystemOfUnits import mm, GeV, MeV, m, deg
+from g4units import mm, GeV, MeV, m, deg
 SIM = DD4hepSimulation()
 
 ## The compact XML file


### PR DESCRIPTION

BEGINRELEASENOTES
- clic_steer, fcc_steer: use g4units instead of dropped SystemOfUnits

ENDRELEASENOTES