### PR TITLE
SkimSecondaryVertices: processor to remove secondary vertices produce…

### DIFF
--- a/Tracking/include/SkimSecondaryVertices.h
+++ b/Tracking/include/SkimSecondaryVertices.h
@@ -1,0 +1,92 @@
+#ifndef SkimSecondaryVertices_h
+#define SkimSecondaryVertices_h 1
+
+#include "marlin/Processor.h"
+#include "lcio.h"
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "DDRec/Surface.h"
+#include "MarlinTrk/IMarlinTrkSystem.h"
+#include <EVENT/LCCollection.h>
+#include <EVENT/MCParticle.h>
+#include <EVENT/Vertex.h>
+#include <EVENT/TrackerHit.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+#include <UTIL/CellIDDecoder.h>
+#include <gsl/gsl_rng.h>
+
+#include <AIDA/AIDA.h>
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TCanvas.h>
+#include <TGraphAsymmErrors.h>
+
+class TTree;
+/* class TFile; */
+
+using namespace lcio ;
+using namespace marlin ;
+using namespace AIDA ;
+
+class SkimSecondaryVertices : public Processor {
+ public:
+       
+        virtual Processor*  newProcessor() { return new SkimSecondaryVertices ; }
+       
+        SkimSecondaryVertices() ;
+        SkimSecondaryVertices(const SkimSecondaryVertices&) = delete;
+        SkimSecondaryVertices& operator=(const SkimSecondaryVertices&) = delete;
+
+        // Initialisation - run at the beginning to start histograms, etc.
+        virtual void init() ;
+       
+        // Called at the beginning of every run
+        virtual void processRunHeader( LCRunHeader* run ) ;
+       
+        // Run over each event - the main algorithm
+        virtual void processEvent( LCEvent * evt ) ;
+       
+        // Run at the end of each event
+        virtual void check( LCEvent * evt ) ;
+       
+        // Called at the very end for cleanup, histogram saving, etc.
+        virtual void end() ;
+       
+        // Call to get collections
+        void getCollection(LCCollection*&, std::string, LCEvent*);
+
+        // Clear the tree
+        void clearTreeVar();
+
+ protected:
+        std::string _inputBuildUpVertices = "";
+        std::string _outputBuildUpVerticesSkimmed = "";
+        std::string _vertexTreeName = "";
+        std::string _vertexSkimmedTreeName = "";
+        int _eventNumber = 0;
+        int _runNumber = 0;
+
+        // Geometry constraints
+        std::vector<double > _barrel_radii = {};
+        double _barrel_halfLength = 0.0;
+        std::vector<double > _endcap_z = {};
+
+        // Trees
+        TTree *_vertexTree = NULL;
+        int _vtxN = 0;
+        std::vector<double > _vtxX = {};
+        std::vector<double > _vtxY = {};
+        std::vector<double > _vtxR = {};
+        std::vector<double > _vtxZ = {};
+        TTree *_vertexSkimmedTree = NULL;
+        int _vtxskimN = 0;
+        std::vector<double > _vtxskimR = {};
+        std::vector<double > _vtxskimZ = {};
+
+};
+
+#endif

--- a/Tracking/src/SkimSecondaryVertices.cc
+++ b/Tracking/src/SkimSecondaryVertices.cc
@@ -1,0 +1,285 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+#include "SkimSecondaryVertices.h"
+
+#include "DD4hep/Detector.h"
+#include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/DetType.h"
+#include "DDRec/DetectorData.h"
+#include "DD4hep/DetectorSelector.h"
+
+#include "marlin/AIDAProcessor.h"
+
+#include "MarlinTrk/HelixTrack.h"
+#include <marlinutil/HelixClass.h>
+
+#include <EVENT/LCCollection.h>
+#include <EVENT/SimTrackerHit.h>
+#include <EVENT/ReconstructedParticle.h>
+#include <EVENT/Vertex.h>
+
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/TrackImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+
+#include <UTIL/CellIDDecoder.h>
+#include <UTIL/LCTrackerConf.h>
+#include <UTIL/LCRelationNavigator.h>
+
+#include <marlinutil/GeometryUtil.h>
+
+#include <AIDA/IAnalysisFactory.h>
+#include <AIDA/IHistogramFactory.h>
+
+#include <TLorentzVector.h>
+#include <TTree.h>
+
+
+using namespace lcio ;
+using namespace marlin ;
+using namespace std ;
+using namespace AIDA ;
+
+using dd4hep::DetType;
+using dd4hep::rec::ZPlanarData;
+using dd4hep::rec::ZDiskPetalsData;
+
+SkimSecondaryVertices aSkimSecondaryVertices;
+/*
+
+   Processor to remove secondary vertices from material interactions and validate the skimmed vertices used for Flavour Tagging. Uses BuildUpVertices info.
+
+*/
+SkimSecondaryVertices::SkimSecondaryVertices() : Processor("SkimSecondaryVertices") {
+
+  // processor description
+  _description = "SkimSecondaryVertices removes secondary vertices from material interactions and creates a skimmed secondary vertices collection to use for the ntuple making for flavour tagging";
+
+  // Input collections
+  registerInputCollection( LCIO::VERTEX,
+                           "BuildUpVertices",
+                           "Name of the Vertex input collection",
+                           _inputBuildUpVertices,
+                           std::string("BuildUpVertices"));
+
+  // Output collection
+  registerOutputCollection( LCIO::VERTEX,
+                            "BuildUpVerticesSkimmed",
+                            "Name of the Vertex skimmed output collection",
+                            _outputBuildUpVerticesSkimmed,
+                            std::string("BuildUpVerticesSkimmed"));
+ 
+  // Output ntuple names
+  registerProcessorParameter( "vertexTreeName",
+                              "Name of the output ntuple",
+                              _vertexTreeName,
+                              std::string("vertexTree"));
+ 
+  registerProcessorParameter( "vertexSkimmedTreeName",
+                              "Name of the output skimmed ntuple",
+                              _vertexSkimmedTreeName,
+                              std::string("vertexSkimmedTree"));
+
+}
+
+void SkimSecondaryVertices::init(){
+
+  // Print the initial parameters
+  printParameters();
+
+  // Reset counters
+  _runNumber = 0;
+  _eventNumber = 0;
+
+  // Initialise histograms
+  AIDAProcessor::histogramFactory(this);
+
+  // Output trees
+  _vertexTree = new TTree(_vertexTreeName.c_str(), _vertexTreeName.c_str());
+  int bufsize = 32000;
+  _vertexTree->Branch("_vtxN",&_vtxN,"_vtxN/I");
+  _vertexTree->Branch("_vtxX","std::vector<double >",&_vtxX,bufsize,0);
+  _vertexTree->Branch("_vtxY","std::vector<double >",&_vtxY,bufsize,0);
+  _vertexTree->Branch("_vtxR","std::vector<double >",&_vtxR,bufsize,0);
+  _vertexTree->Branch("_vtxZ","std::vector<double >",&_vtxZ,bufsize,0);
+
+  _vertexSkimmedTree = new TTree(_vertexSkimmedTreeName.c_str(), _vertexSkimmedTreeName.c_str());
+  _vertexSkimmedTree->Branch("_vtxskimN",&_vtxskimN,"_vtxskimN/I");
+  _vertexSkimmedTree->Branch("_vtxskimR","std::vector<double >",&_vtxskimR,bufsize,0);
+  _vertexSkimmedTree->Branch("_vtxskimZ","std::vector<double >",&_vtxskimZ,bufsize,0);
+ 
+  // Get detector data
+
+  dd4hep::Detector &mainDetector = dd4hep::Detector::getInstance();
+
+  // - barrels
+
+  const std::vector<dd4hep::DetElement>& barrelDets = dd4hep::DetectorSelector(mainDetector).detectors((dd4hep::DetType::VERTEX && dd4hep::DetType::BARREL));
+ 
+  streamlog_out( DEBUG0 ) << "Number of vertex barrel dets: " << barrelDets.size() << endl;
+
+  for(unsigned int i=0; i<barrelDets.size(); i++){
+
+    try{
+      dd4hep::rec::ZPlanarData* barrels = barrelDets.at(i).extension<dd4hep::rec::ZPlanarData>();
+      std::vector<ZPlanarData::LayerLayout> layers = barrels->layers;
+
+      for(unsigned int l=0; l<layers.size(); l++){
+        ZPlanarData::LayerLayout layer = layers[l];
+        streamlog_out( DEBUG0 ) << "***BARREL LAYER " << l << std::endl;
+       
+        streamlog_out( DEBUG0 ) << "distanceSupport: " << layer.distanceSupport << "\t thicknessSupport: " << layer.thicknessSupport
+                  << "\n offsetSupport: " << layer.offsetSupport << "\t widthSupport: " << layer.widthSupport << "\t zHalfSupport: " << layer.zHalfSupport
+                  << "\n distanceSensitive:  " << layer.distanceSensitive << "\t thicknessSensitive: " << layer.thicknessSensitive
+                  << "\n offsetSensitive: " << layer.offsetSensitive << "\t widthSensitive: " << layer.widthSensitive << "\t zHalfSensitive: " << layer.zHalfSensitive << std::endl;
+        _barrel_radii.push_back(layer.distanceSupport);
+        _barrel_halfLength = layer.zHalfSupport;
+
+      }
+    } catch (std::exception &e) {
+      if( _barrel_radii.size() != barrelDets.size() )_barrel_radii.clear();
+      streamlog_out( DEBUG0 ) << "Caught exception " << e.what() << std::endl;
+    }
+
+  }
+
+  // - disks
+
+  const std::vector<dd4hep::DetElement>& endcapDets = dd4hep::DetectorSelector(mainDetector).detectors((dd4hep::DetType::VERTEX && dd4hep::DetType::ENDCAP));
+
+  streamlog_out( DEBUG0 ) << "Number of vertex endcap dets: " << endcapDets.size() << endl;
+
+  for(unsigned int i=0; i<endcapDets.size(); i++){
+
+    try{
+      dd4hep::rec::ZDiskPetalsData* endcaps = endcapDets.at(i).extension<dd4hep::rec::ZDiskPetalsData>();
+      std::vector<ZDiskPetalsData::LayerLayout> disks = endcaps->layers;
+
+      for(unsigned int d=0; d<disks.size(); d++){
+        ZDiskPetalsData::LayerLayout disk = disks[d];
+        streamlog_out( DEBUG0 ) << "***ENDCAP LAYER " << d << std::endl;
+        streamlog_out( DEBUG0 ) << "zPosition: " << disk.zPosition << std::endl;
+        streamlog_out( DEBUG0 ) << "distanceSupport: " << disk.distanceSupport << "\t thicknessSupport: " << disk.thicknessSupport
+                  << "\n zOffsetSupport: " << disk.zOffsetSupport << "\t widthInnerSupport: " << disk.widthInnerSupport << "\t widthOuterSupport: " << disk.widthOuterSupport <<"\t lengthSupport: " << disk.lengthSupport
+                  << "\n distanceSensitive:  " << disk.distanceSensitive << "\t thicknessSensitive: " << disk.thicknessSensitive
+                  << "\n zOffsetSensitive: " << disk.zOffsetSensitive << "\t widthInnerSensitive: " << disk.widthInnerSensitive << "\t widthOuterSensitive: " << disk.widthOuterSensitive << "\t lengthSensitive: " << disk.lengthSensitive << std::endl;  
+
+        _endcap_z.push_back(disk.zPosition);
+
+      }
+
+    }
+    catch (std::exception &e) {
+      if( _endcap_z.size() != endcapDets.size() ) _endcap_z.clear();
+      streamlog_out( DEBUG0 ) << "Caught exception " << e.what() << std::endl;
+    }
+
+  }
+
+}
+
+void SkimSecondaryVertices::processRunHeader( LCRunHeader* ){
+  ++_runNumber;
+}
+
+void SkimSecondaryVertices::processEvent( LCEvent* evt ){
+
+  streamlog_out( MESSAGE ) << "Processing event " << _eventNumber << std::endl;
+
+  // Get the collection of Vertices
+  LCCollection *vtxCollection = 0;
+  getCollection(vtxCollection, _inputBuildUpVertices, evt);
+  if(vtxCollection == 0) return;
+
+  int nVtx = vtxCollection->getNumberOfElements();
+  _vtxN = nVtx;
+  streamlog_out( DEBUG0 ) << nVtx << " vertices in event " << _eventNumber << std::endl;
+
+  // Output vertex collection to fill in
+  LCCollectionVec* vtxVec = new LCCollectionVec(LCIO::VERTEX);
+  vtxVec->setSubset(true); // flag as subset
+  int vtxskimN = 0;
+
+  for(int i=0; i<nVtx; i++){
+    Vertex *vtx = dynamic_cast<Vertex*> (vtxCollection->getElementAt(i));
+    double vtxX = vtx->getPosition()[0];
+    double vtxY = vtx->getPosition()[1];
+    double vtxR = sqrt(vtxX*vtxX + vtxY*vtxY);
+    double vtxZ = vtx->getPosition()[2];
+    _vtxX.push_back(vtxX);
+    _vtxY.push_back(vtxY);
+    _vtxR.push_back(vtxR);
+    _vtxZ.push_back(vtxZ);
+    streamlog_out( DEBUG0 ) << "** Vertex " << i << ": x = " << vtxX << "\t y = " << vtxY << "\t z = " << vtxZ << std::endl;
+
+    bool keep = true;
+    for(unsigned int l=0; l<_barrel_radii.size(); l++){
+      if(l%2==0){
+        if(_vtxR.at(i) >= _barrel_radii.at(l) && _vtxR.at(i) < _barrel_radii.at(l+1) && abs(_vtxZ.at(i)) <= _barrel_halfLength ){
+          keep = false;
+          streamlog_out( DEBUG0 ) << "Vertex skimmed: r = " << _vtxR.at(i) << "\t z = " << _vtxZ.at(i) << std::endl;
+        }
+      }
+    }
+    for(unsigned int l=0; l<_endcap_z.size(); l++){
+      if(l%2==0){
+        if(abs(_vtxZ.at(i)) <= _endcap_z.at(l) && abs(_vtxZ.at(i)) > _endcap_z.at(l+1)){
+          keep = false;
+          streamlog_out( DEBUG0 ) << "Vertex skimmed: z = " << _vtxZ.at(i) << std::endl;
+        }
+      }
+    }
+
+    if(keep){
+      vtxVec->addElement(vtx);
+      _vtxskimR.push_back(vtxR);
+      _vtxskimZ.push_back(vtxZ);
+      vtxskimN++;
+    }
+  }
+
+  _vtxskimN = vtxskimN;
+
+  evt->addCollection(vtxVec, _outputBuildUpVerticesSkimmed);
+
+  _vertexTree->Fill();
+  _vertexSkimmedTree->Fill();
+  _eventNumber++;
+
+  // Clear the trees
+  clearTreeVar();
+}
+
+void SkimSecondaryVertices::check( LCEvent *) {
+  //nothing to check at the moment
+}
+
+void SkimSecondaryVertices::end(){
+
+  streamlog_out( MESSAGE ) << " end() " << name() << " processed " << _eventNumber << " events in " << _runNumber << " runs " << std::endl;
+
+}
+
+void SkimSecondaryVertices::getCollection(LCCollection*& collection, std::string collectionName, LCEvent* evt){
+
+  try{
+    collection = evt->getCollection(collectionName);
+  }
+  catch(DataNotAvailableException &e){
+    streamlog_out( DEBUG5 ) << " - cannot get collection. Collection " << collectionName.c_str() << " is unavailable" << std::endl;
+    return;
+  }
+  return;
+}
+
+void SkimSecondaryVertices::clearTreeVar(){
+
+  _vtxX.clear();
+  _vtxY.clear();
+  _vtxR.clear();
+  _vtxZ.clear();
+
+  _vtxskimR.clear();
+  _vtxskimZ.clear();
+ 
+}

--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -113,12 +113,20 @@
     </if>
 
     <processor name="VertexFinder"/>
-    <processor name="JetClusteringAndRefiner"/>
 
     <if condition="Config.VertexUnconstrainedON">
       <processor name="VertexFinderUnconstrained"/>
     </if>
 
+    <if condition="Config.SkimmingSecondaryVerticesOFF">
+      <processor name="RenameVertexCollection"/>
+    </if>
+
+    <if condition="Config.SkimmingSecondaryVerticesON">
+      <processor name="MySkimSecondaryVertices"/>
+    </if>
+
+    <processor name="JetClusteringAndRefiner"/>
 
     <!-- ========== output  ========== -->
 
@@ -168,6 +176,10 @@
     <parameter name="VertexUnconstrained" type="string">OFF </parameter>
     <!--Possible values and conditions for option Tracking-->
     <parameter name="VertexUnconstrainedChoices" type="StringVec">ON OFF  </parameter>
+    <!--Which option to use for SkimmingSecondaryVertiecs: ON, OFF. Then use, e.g., Config.SkimmingSecondaryVerticesOFF in the condition-->
+    <parameter name="SkimmingSecondaryVertices" type="string">OFF </parameter>
+    <!--Possible values and conditions for option SkimmingSecondaryVertices-->
+    <parameter name="SkimmingSecondaryVerticesChoices" type="StringVec">ON OFF  </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
   </processor>
 
@@ -1650,6 +1662,22 @@
       <parameter name="PrimaryVertexFinder.BeamspotConstraint" type="bool">0 </parameter>
     </processor>
   </group>
+
+  <!-- ========== Rename vertex collection (to have same output collection name as SkimSecondaryVertices ================================== -->
+
+  <processor name="RenameVertexCollection" type="MergeCollections">
+    <parameter name="CollectionParameterIndex" type="int">0 </parameter>
+    <parameter name="InputCollectionIDs" type="IntVec"> </parameter>
+    <parameter name="InputCollections" type="StringVec"> BuildUpVertices </parameter>
+    <parameter name="OutputCollection" type="string"> BuildUpVerticesSkimmed </parameter>
+  </processor>
+
+  <processor name="MySkimSecondaryVertices" type="SkimSecondaryVertices">
+    <parameter name="BuildUpVertices" type="string"> BuildUpVertices </parameter>
+    <parameter name="BuildUpVerticesSkimmed" type="string"> BuildUpVerticesSkimmed </parameter>
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+  </processor>
+
 
   <processor name="JetClusteringAndRefiner" type="LcfiplusProcessor">
     <parameter name="Algorithms" type="stringVec"> JetClustering JetVertexRefiner </parameter>

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -72,12 +72,20 @@
     </if>
 
     <processor name="VertexFinder"/>
-    <processor name="JetClusteringAndRefiner"/>
 
     <if condition="Config.VertexUnconstrainedON">
       <processor name="VertexFinderUnconstrained"/>
     </if> 
-    
+        
+    <if condition="Config.SkimmingSecondaryVerticesOFF">
+      <processor name="RenameVertexCollection"/>
+    </if>
+
+    <if condition="Config.SkimmingSecondaryVerticesON">
+      <processor name="MySkimSecondaryVertices"/>
+    </if>
+
+    <processor name="JetClusteringAndRefiner"/>
 
     <!-- ========== output  ========== -->
 
@@ -123,6 +131,10 @@
     <parameter name="VertexUnconstrained" type="string">OFF </parameter>
     <!--Possible values and conditions for option Tracking-->
     <parameter name="VertexUnconstrainedChoices" type="StringVec">ON OFF  </parameter>
+    <!--Which option to use for SkimmingSecondaryVertiecs: ON, OFF. Then use, e.g., Config.SkimmingSecondaryVerticesOFF in the condition-->
+    <parameter name="SkimmingSecondaryVertices" type="string">OFF </parameter>
+    <!--Possible values and conditions for option SkimmingSecondaryVertices-->
+    <parameter name="SkimmingSecondaryVerticesChoices" type="StringVec">ON OFF  </parameter>
   </processor>
 
   <group name="Overlay">
@@ -1352,6 +1364,22 @@
     </processor>
 
   </group>
+
+  <!-- ========== Rename vertex collection (to have same output collection name as SkimSecondaryVertices ================================== -->
+
+  <processor name="RenameVertexCollection" type="MergeCollections">
+    <parameter name="CollectionParameterIndex" type="int">0 </parameter>
+    <parameter name="InputCollectionIDs" type="IntVec"> </parameter>
+    <parameter name="InputCollections" type="StringVec"> BuildUpVertices </parameter>
+    <parameter name="OutputCollection" type="string"> BuildUpVerticesSkimmed </parameter>
+  </processor>
+
+
+  <processor name="MySkimSecondaryVertices" type="SkimSecondaryVertices">
+    <parameter name="BuildUpVertices" type="string"> BuildUpVertices </parameter>
+    <parameter name="BuildUpVerticesSkimmed" type="string"> BuildUpVerticesSkimmed </parameter>
+    <parameter name="Verbosity" type="string"> MESSAGE </parameter>
+  </processor>
 
 
   <processor name="JetClusteringAndRefiner" type="LcfiplusProcessor">

--- a/source/Conditions/include/CLICRecoConfig.h
+++ b/source/Conditions/include/CLICRecoConfig.h
@@ -45,12 +45,15 @@ protected:
   const Choices m_beamcalPossibleOptions{"3TeV", "380GeV"};
   // VertexUnconstrained
   const Choices m_vertexUnconstrainedPossibleOptions{"ON","OFF"};
+  // SkimmingSecondaryVertices
+  const Choices m_skimmingSecondaryVerticesPossibleOptions{"ON","OFF"};
 
   std::vector<std::tuple<std::string, std::string, Choices>> m_allOptions =
     {{"Tracking", "Conformal", m_trackingPossibleOptions},
      {"BeamCal",  "3TeV", m_beamcalPossibleOptions},
      {"Overlay",  "False", m_overlayPossibleOptions},
-     {"VertexUnconstrained", "OFF", m_vertexUnconstrainedPossibleOptions}};
+     {"VertexUnconstrained", "OFF", m_vertexUnconstrainedPossibleOptions},
+     {"SkimmingSecondaryVertices","OFF",m_skimmingSecondaryVerticesPossibleOptions}};
 
 
 protected:


### PR DESCRIPTION
…d in the interaction with material to properly run flavour tagging



BEGINRELEASENOTES
- SkimSecondaryVertices processor removes secondary vertices produced in the interaction with the material in the vertex detector (barrels & endcaps)
- CLICRecoConfig contains the option to select/unselect the skimming (OFF by default)
- clicConfig/clicReconstruction.xml and fcceeConfig/fccReconstruction.xml updated accordingly

ENDRELEASENOTES