### PR TITLE
FCC/CLIC Reco: fix 'spelling' of TooManyTracks parameter value, 5e5 d…

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -452,7 +452,7 @@
     <!--retry with tightened parameters, when too many tracks are being created-->
     <parameter name="RetryTooManyTracks" type="bool">false </parameter>
     <!--Number of tracks that is considered too many-->
-    <parameter name="TooManyTracks" type="int">5e5 </parameter>
+    <parameter name="TooManyTracks" type="int">500000 </parameter>
     <!--sort results from kdtree search-->
     <parameter name="SortTreeResults" type="bool">true </parameter>
 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -367,7 +367,7 @@
     <!--retry with tightened parameters, when too many tracks are being created-->
     <parameter name="RetryTooManyTracks" type="bool">false </parameter>
     <!--Number of tracks that is considered too many-->
-    <parameter name="TooManyTracks" type="int">5e5 </parameter>
+    <parameter name="TooManyTracks" type="int">500000 </parameter>
     <!--sort results from kdtree search-->
     <parameter name="SortTreeResults" type="bool">true </parameter>
 


### PR DESCRIPTION
…oes not parse into integer



BEGINRELEASENOTES
- FCC/ClicReco:  fix 'spelling' of TooManyTracks parameter value

ENDRELEASENOTES