### PR TITLE
HighPTCut set to 0.0 in CT ExtendTracks 

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -465,7 +465,7 @@
       @Functions : CombineCollections, BuildNewTracks
       [VXDEncap]
       @Collections : VXDEndcapTrackerHits
-      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 10.0;
+      @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
       @Flags : HighPTFit, VertexToTracker
       @Functions : CombineCollections, ExtendTracks
       [LowerCellAngle1]
@@ -480,7 +480,7 @@
       @Functions : BuildNewTracks, SortTracks
       [Tracker]
       @Collections : ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 1.0;
+      @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; SlopeZRange: 10.0; HighPTCut: 0.0;
       @Flags : HighPTFit, VertexToTracker, RadialSearch
       @Functions : CombineCollections, ExtendTracks
       [Displaced]


### PR DESCRIPTION
BEGINRELEASENOTES
- CLIC Reco: ConformalTracking: Set HighPTCut to 0
    - According to a study on the conformal tracking fit for the ExtendTracks step, the quadratic term in the fit is not needed for the low-pT tracks. Results for ttbar w/o and w/ overlay shows unchanged level of tracking efficiency, slightly increase of fakerate, and reduction CPU time of 13%. Full set of results [here](https://indico.cern.ch/event/848916/contributions/3567053/attachments/1909256/3154418/EricaBrondolin_20190917_LowPtStudies.pdf).

ENDRELEASENOTES