### PR TITLE
Jet study analyzer - for discussion

### DIFF
--- a/Calorimetry/include/JetAnalyzer.h
+++ b/Calorimetry/include/JetAnalyzer.h
@@ -64,19 +64,20 @@ protected:
   // Run and event counters
   int m_eventNumber=0;
   int m_runNumber=0;
-  //parton level information, save two Z daughters
+  //parton level information, save first quark in history
   int m_d1_mcPDGID=0;
   float m_d1_mcE=0;
   float m_d1_mcPx=0;
   float m_d1_mcPy=0;
   float m_d1_mcPz=0;
-
+  //parton level information, save second quark in history
   int m_d2_mcPDGID=0;
   float m_d2_mcE=0;
   float m_d2_mcPx=0;
   float m_d2_mcPy=0;
   float m_d2_mcPz=0;
   //particle level information sums --> visible and invisible energy
+
   //only neutrinos
   float m_E_trueInv=0;
   float m_px_trueInv=0;
@@ -84,10 +85,10 @@ protected:
   float m_pz_trueInv=0;
 
   //all visible particles
-  float m_E_trueAll=0;
-  float m_px_trueAll=0;
-  float m_py_trueAll=0;
-  float m_pz_trueAll=0;
+  float m_E_trueVis=0;
+  float m_px_trueVis=0;
+  float m_py_trueVis=0;
+  float m_pz_trueVis=0;
 
   //all reconstructed particles
   float m_E_totPFO=0;
@@ -95,6 +96,7 @@ protected:
   float m_py_totPFO=0;
   float m_pz_totPFO=0;
 
+  //if extended parton quantities are saved: dibosons and their decay products
   std::vector<float>* m_trueME_E=NULL;
   std::vector<float>* m_trueME_Px=NULL;
   std::vector<float>* m_trueME_Py=NULL;

--- a/Calorimetry/include/JetAnalyzer.h
+++ b/Calorimetry/include/JetAnalyzer.h
@@ -1,0 +1,129 @@
+#ifndef JetAnalyzer_h
+#define JetAnalyzer_h 1
+
+#include "marlin/Processor.h"
+
+#include "lcio.h"
+
+#include <EVENT/LCCollection.h>
+#include <EVENT/MCParticle.h>
+#include <EVENT/ReconstructedParticle.h>
+
+
+#include "TH2F.h"
+#include "TH1D.h"
+#include "TProfile2D.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TLorentzVector.h"
+#include <map>
+
+using namespace lcio ;
+using namespace marlin ;
+
+class TTree;
+
+
+class JetAnalyzer : public Processor {
+                
+public:
+        
+    virtual Processor*  newProcessor() { return new JetAnalyzer ; }
+    
+    JetAnalyzer() ;
+
+    JetAnalyzer(const JetAnalyzer&) = delete;
+    JetAnalyzer& operator=(const JetAnalyzer&) = delete;
+    
+    // Initialisation - run at the beginning to start histograms, etc.
+    virtual void init() ;
+    
+    // Called at the beginning of every run
+    virtual void processRunHeader( LCRunHeader* run ) ;
+    
+    // Run over each event - the main algorithm
+    virtual void processEvent( LCEvent * evt ) ;
+    
+    // Run at the end of each event
+    virtual void check( LCEvent * evt ) ;
+    
+    // Called at the very end for cleanup, histogram saving, etc.
+    virtual void end() ;
+    
+        
+protected:
+        
+    std::string m_inputMCParticleCollection="";
+    std::string m_inputRECOParticleCollection="";
+    std::string m_genjetColName="";
+    std::string m_recojetColName="";
+
+
+    std::string m_rootFileName="";
+    
+    // Run and event counters
+    int m_eventNumber=0;
+    int m_runNumber=0;
+    //parton level information, save two Z daughters
+    int m_d1_mcPDGID=0;
+    float m_d1_mcE=0;
+    float m_d1_mcPx=0;
+    float m_d1_mcPy=0;
+    float m_d1_mcPz=0;
+
+    int m_d2_mcPDGID=0;
+    float m_d2_mcE=0;
+    float m_d2_mcPx=0;
+    float m_d2_mcPy=0;
+    float m_d2_mcPz=0;
+    //particle level information sums --> visible and invisible energy
+    //only neutrinos
+    float m_E_trueInv=0;
+    float m_px_trueInv=0;
+    float m_py_trueInv=0;
+    float m_pz_trueInv=0;
+
+    //all visible particles
+    float m_E_trueAll=0;
+    float m_px_trueAll=0;
+    float m_py_trueAll=0;
+    float m_pz_trueAll=0;
+
+    //all reconstructed particles
+    float m_E_totPFO=0;
+    float m_px_totPFO=0;
+    float m_py_totPFO=0;
+    float m_pz_totPFO=0;
+
+    std::vector<float>* m_trueME_E=NULL;
+    std::vector<float>* m_trueME_Px=NULL;
+    std::vector<float>* m_trueME_Py=NULL;
+    std::vector<float>* m_trueME_Pz=NULL;
+    std::vector<int>* m_trueME_PDGID=NULL;
+
+    std::vector<float>* m_genJet_E=NULL;
+    std::vector<float>* m_genJet_Px=NULL;
+    std::vector<float>* m_genJet_Py=NULL;
+    std::vector<float>* m_genJet_Pz=NULL;
+
+    std::vector<float>* m_recoJet_E=NULL;
+    std::vector<float>* m_recoJet_Px=NULL;
+    std::vector<float>* m_recoJet_Py=NULL;
+    std::vector<float>* m_recoJet_Pz=NULL;
+
+    
+    // Call to get collections
+    void getCollection(LCCollection*&, std::string, LCEvent*);
+    
+    
+    TFile * m_rootFile=NULL;
+    TTree* m_outputTree=NULL;
+    bool m_fillMEInfo=false;
+    bool m_performDiBosonChecks=false;
+
+} ;
+
+#endif
+
+
+

--- a/Calorimetry/include/JetAnalyzer.h
+++ b/Calorimetry/include/JetAnalyzer.h
@@ -25,101 +25,101 @@ class TTree;
 
 
 class JetAnalyzer : public Processor {
-                
+  
 public:
-        
-    virtual Processor*  newProcessor() { return new JetAnalyzer ; }
-    
-    JetAnalyzer() ;
+  
+  virtual Processor*  newProcessor() { return new JetAnalyzer ; }
+  
+  JetAnalyzer() ;
 
-    JetAnalyzer(const JetAnalyzer&) = delete;
-    JetAnalyzer& operator=(const JetAnalyzer&) = delete;
-    
-    // Initialisation - run at the beginning to start histograms, etc.
-    virtual void init() ;
-    
-    // Called at the beginning of every run
-    virtual void processRunHeader( LCRunHeader* run ) ;
-    
-    // Run over each event - the main algorithm
-    virtual void processEvent( LCEvent * evt ) ;
-    
-    // Run at the end of each event
-    virtual void check( LCEvent * evt ) ;
-    
-    // Called at the very end for cleanup, histogram saving, etc.
-    virtual void end() ;
-    
-        
+  JetAnalyzer(const JetAnalyzer&) = delete;
+  JetAnalyzer& operator=(const JetAnalyzer&) = delete;
+  
+  // Initialisation - run at the beginning to start histograms, etc.
+  virtual void init() ;
+  
+  // Called at the beginning of every run
+  virtual void processRunHeader( LCRunHeader* run ) ;
+  
+  // Run over each event - the main algorithm
+  virtual void processEvent( LCEvent * evt ) ;
+  
+  // Run at the end of each event
+  virtual void check( LCEvent * evt ) ;
+  
+  // Called at the very end for cleanup, histogram saving, etc.
+  virtual void end() ;
+  
+  
 protected:
-        
-    std::string m_inputMCParticleCollection="";
-    std::string m_inputRECOParticleCollection="";
-    std::string m_genjetColName="";
-    std::string m_recojetColName="";
+  
+  std::string m_inputMCParticleCollection="";
+  std::string m_inputRECOParticleCollection="";
+  std::string m_genjetColName="";
+  std::string m_recojetColName="";
 
 
-    std::string m_rootFileName="";
-    
-    // Run and event counters
-    int m_eventNumber=0;
-    int m_runNumber=0;
-    //parton level information, save two Z daughters
-    int m_d1_mcPDGID=0;
-    float m_d1_mcE=0;
-    float m_d1_mcPx=0;
-    float m_d1_mcPy=0;
-    float m_d1_mcPz=0;
+  std::string m_rootFileName="";
+  
+  // Run and event counters
+  int m_eventNumber=0;
+  int m_runNumber=0;
+  //parton level information, save two Z daughters
+  int m_d1_mcPDGID=0;
+  float m_d1_mcE=0;
+  float m_d1_mcPx=0;
+  float m_d1_mcPy=0;
+  float m_d1_mcPz=0;
 
-    int m_d2_mcPDGID=0;
-    float m_d2_mcE=0;
-    float m_d2_mcPx=0;
-    float m_d2_mcPy=0;
-    float m_d2_mcPz=0;
-    //particle level information sums --> visible and invisible energy
-    //only neutrinos
-    float m_E_trueInv=0;
-    float m_px_trueInv=0;
-    float m_py_trueInv=0;
-    float m_pz_trueInv=0;
+  int m_d2_mcPDGID=0;
+  float m_d2_mcE=0;
+  float m_d2_mcPx=0;
+  float m_d2_mcPy=0;
+  float m_d2_mcPz=0;
+  //particle level information sums --> visible and invisible energy
+  //only neutrinos
+  float m_E_trueInv=0;
+  float m_px_trueInv=0;
+  float m_py_trueInv=0;
+  float m_pz_trueInv=0;
 
-    //all visible particles
-    float m_E_trueAll=0;
-    float m_px_trueAll=0;
-    float m_py_trueAll=0;
-    float m_pz_trueAll=0;
+  //all visible particles
+  float m_E_trueAll=0;
+  float m_px_trueAll=0;
+  float m_py_trueAll=0;
+  float m_pz_trueAll=0;
 
-    //all reconstructed particles
-    float m_E_totPFO=0;
-    float m_px_totPFO=0;
-    float m_py_totPFO=0;
-    float m_pz_totPFO=0;
+  //all reconstructed particles
+  float m_E_totPFO=0;
+  float m_px_totPFO=0;
+  float m_py_totPFO=0;
+  float m_pz_totPFO=0;
 
-    std::vector<float>* m_trueME_E=NULL;
-    std::vector<float>* m_trueME_Px=NULL;
-    std::vector<float>* m_trueME_Py=NULL;
-    std::vector<float>* m_trueME_Pz=NULL;
-    std::vector<int>* m_trueME_PDGID=NULL;
+  std::vector<float>* m_trueME_E=NULL;
+  std::vector<float>* m_trueME_Px=NULL;
+  std::vector<float>* m_trueME_Py=NULL;
+  std::vector<float>* m_trueME_Pz=NULL;
+  std::vector<int>* m_trueME_PDGID=NULL;
 
-    std::vector<float>* m_genJet_E=NULL;
-    std::vector<float>* m_genJet_Px=NULL;
-    std::vector<float>* m_genJet_Py=NULL;
-    std::vector<float>* m_genJet_Pz=NULL;
+  std::vector<float>* m_genJet_E=NULL;
+  std::vector<float>* m_genJet_Px=NULL;
+  std::vector<float>* m_genJet_Py=NULL;
+  std::vector<float>* m_genJet_Pz=NULL;
 
-    std::vector<float>* m_recoJet_E=NULL;
-    std::vector<float>* m_recoJet_Px=NULL;
-    std::vector<float>* m_recoJet_Py=NULL;
-    std::vector<float>* m_recoJet_Pz=NULL;
+  std::vector<float>* m_recoJet_E=NULL;
+  std::vector<float>* m_recoJet_Px=NULL;
+  std::vector<float>* m_recoJet_Py=NULL;
+  std::vector<float>* m_recoJet_Pz=NULL;
 
-    
-    // Call to get collections
-    void getCollection(LCCollection*&, std::string, LCEvent*);
-    
-    
-    TFile * m_rootFile=NULL;
-    TTree* m_outputTree=NULL;
-    bool m_fillMEInfo=false;
-    bool m_performDiBosonChecks=false;
+  
+  // Call to get collections
+  void getCollection(LCCollection*&, std::string, LCEvent*);
+  
+  
+  TFile * m_rootFile=NULL;
+  TTree* m_outputTree=NULL;
+  bool m_fillMEInfo=false;
+  bool m_performDiBosonChecks=false;
 
 } ;
 

--- a/Calorimetry/include/TrueMCintoRecoForJets.h
+++ b/Calorimetry/include/TrueMCintoRecoForJets.h
@@ -15,49 +15,49 @@ using namespace marlin ;
 
 
 class TrueMCintoRecoForJets : public Processor {
-                
+  
 public:
-        
-    virtual Processor*  newProcessor() { return new TrueMCintoRecoForJets ; }
-    
-    TrueMCintoRecoForJets() ;
+  
+  virtual Processor*  newProcessor() { return new TrueMCintoRecoForJets ; }
+  
+  TrueMCintoRecoForJets() ;
 
-    TrueMCintoRecoForJets(const TrueMCintoRecoForJets&) = delete;
-    TrueMCintoRecoForJets& operator=(const TrueMCintoRecoForJets&) = delete;
-    
-    // Initialisation - run at the beginning to start histograms, etc.
-    virtual void init() ;
-    
-    // Called at the beginning of every run
-    virtual void processRunHeader( LCRunHeader* run ) ;
-    
-    // Run over each event - the main algorithm
-    virtual void processEvent( LCEvent * evt ) ;
-    
-    // Run at the end of each event
-    virtual void check( LCEvent * evt ) ;
-    
-    // Called at the very end for cleanup, histogram saving, etc.
-    virtual void end() ;
-    
-        
+  TrueMCintoRecoForJets(const TrueMCintoRecoForJets&) = delete;
+  TrueMCintoRecoForJets& operator=(const TrueMCintoRecoForJets&) = delete;
+  
+  // Initialisation - run at the beginning to start histograms, etc.
+  virtual void init() ;
+  
+  // Called at the beginning of every run
+  virtual void processRunHeader( LCRunHeader* run ) ;
+  
+  // Run over each event - the main algorithm
+  virtual void processEvent( LCEvent * evt ) ;
+  
+  // Run at the end of each event
+  virtual void check( LCEvent * evt ) ;
+  
+  // Called at the very end for cleanup, histogram saving, etc.
+  virtual void end() ;
+  
+  
 protected:
-        
-    std::string m_inputMCParticleCollection="";
-    std::string m_outputRECOParticleCollection="";
+  
+  std::string m_inputMCParticleCollection="";
+  std::string m_outputRECOParticleCollection="";
 
-    std::string m_inputRecoParticleCollection="";
-    std::string m_outputRecoNoLepParticleCollection="";
+  std::string m_inputRecoParticleCollection="";
+  std::string m_outputRecoNoLepParticleCollection="";
  
-    // Call to get collections
-    void getCollection(LCCollection*&, std::string, LCEvent*);
+  // Call to get collections
+  void getCollection(LCCollection*&, std::string, LCEvent*);
 
-    bool m_vetoBosonLeptons=false;
-    bool m_vetoBosonLeptonsOnReco=false;
-    bool m_ignoreNeutrinosInMCJets=true;
-    void fillStableDaughterSet(MCParticle*, std::set<MCParticle*> &);
+  bool m_vetoBosonLeptons=false;
+  bool m_vetoBosonLeptonsOnReco=false;
+  bool m_ignoreNeutrinosInMCJets=true;
+  void fillStableDaughterSet(MCParticle*, std::set<MCParticle*> &);
 
-    float m_cosAngle_pfo_lepton = 0.995;//corresponds to 5.73 degrees
+  float m_cosAngle_pfo_lepton = 0.995;//corresponds to 5.73 degrees
 
 } ;
 

--- a/Calorimetry/include/TrueMCintoRecoForJets.h
+++ b/Calorimetry/include/TrueMCintoRecoForJets.h
@@ -1,0 +1,65 @@
+#ifndef TrueMCintoRecoForJets_h
+#define TrueMCintoRecoForJets_h 1
+
+#include "marlin/Processor.h"
+
+#include "lcio.h"
+
+#include <EVENT/LCCollection.h>
+#include <EVENT/MCParticle.h>
+#include <EVENT/ReconstructedParticle.h>
+#include <set>
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+class TrueMCintoRecoForJets : public Processor {
+                
+public:
+        
+    virtual Processor*  newProcessor() { return new TrueMCintoRecoForJets ; }
+    
+    TrueMCintoRecoForJets() ;
+
+    TrueMCintoRecoForJets(const TrueMCintoRecoForJets&) = delete;
+    TrueMCintoRecoForJets& operator=(const TrueMCintoRecoForJets&) = delete;
+    
+    // Initialisation - run at the beginning to start histograms, etc.
+    virtual void init() ;
+    
+    // Called at the beginning of every run
+    virtual void processRunHeader( LCRunHeader* run ) ;
+    
+    // Run over each event - the main algorithm
+    virtual void processEvent( LCEvent * evt ) ;
+    
+    // Run at the end of each event
+    virtual void check( LCEvent * evt ) ;
+    
+    // Called at the very end for cleanup, histogram saving, etc.
+    virtual void end() ;
+    
+        
+protected:
+        
+    std::string m_inputMCParticleCollection="";
+    std::string m_outputRECOParticleCollection="";
+
+    std::string m_inputRecoParticleCollection="";
+    std::string m_outputRecoNoLepParticleCollection="";
+ 
+    // Call to get collections
+    void getCollection(LCCollection*&, std::string, LCEvent*);
+
+    bool m_vetoBosonLeptons=false;
+    bool m_vetoBosonLeptonsOnReco=false;
+    void fillStableDaughterSet(MCParticle*, std::set<MCParticle*> &);
+
+} ;
+
+
+#endif
+
+
+

--- a/Calorimetry/include/TrueMCintoRecoForJets.h
+++ b/Calorimetry/include/TrueMCintoRecoForJets.h
@@ -54,6 +54,7 @@ protected:
 
     bool m_vetoBosonLeptons=false;
     bool m_vetoBosonLeptonsOnReco=false;
+    bool m_ignoreNeutrinosInMCJets=true;
     void fillStableDaughterSet(MCParticle*, std::set<MCParticle*> &);
 
 } ;

--- a/Calorimetry/include/TrueMCintoRecoForJets.h
+++ b/Calorimetry/include/TrueMCintoRecoForJets.h
@@ -57,6 +57,8 @@ protected:
     bool m_ignoreNeutrinosInMCJets=true;
     void fillStableDaughterSet(MCParticle*, std::set<MCParticle*> &);
 
+    float m_cosAngle_pfo_lepton = 0.995;//corresponds to 5.73 degrees
+
 } ;
 
 

--- a/Calorimetry/src/JetAnalyzer.cc
+++ b/Calorimetry/src/JetAnalyzer.cc
@@ -107,10 +107,10 @@ void JetAnalyzer::init() {
   m_py_trueInv = 0;
   m_pz_trueInv = 0;
 
-  m_E_trueAll  = 0;
-  m_px_trueAll = 0;
-  m_py_trueAll = 0;
-  m_pz_trueAll = 0;
+  m_E_trueVis  = 0;
+  m_px_trueVis = 0;
+  m_py_trueVis = 0;
+  m_pz_trueVis = 0;
 
   m_E_totPFO  = 0;
   m_px_totPFO = 0;
@@ -167,13 +167,13 @@ void JetAnalyzer::init() {
   m_outputTree->Branch("d2_mcPy",&m_d2_mcPy,"d2_mcPy/F");
   m_outputTree->Branch("d2_mcPz",&m_d2_mcPz,"d2_mcPz/F");
 
-  //true particle level, exclude neutrinos
-  m_outputTree->Branch("E_trueAll" ,&m_E_trueAll, "E_trueAll/F");
-  m_outputTree->Branch("Px_trueAll",&m_px_trueAll,"Px_trueAll/F");
-  m_outputTree->Branch("Py_trueAll",&m_py_trueAll,"Py_trueAll/F");
-  m_outputTree->Branch("Pz_trueAll",&m_pz_trueAll,"Pz_trueAll/F");
+  //true particle level, exclude neutrinos, true visible content
+  m_outputTree->Branch("E_trueVis" ,&m_E_trueVis, "E_trueVis/F");
+  m_outputTree->Branch("Px_trueVis",&m_px_trueVis,"Px_trueVis/F");
+  m_outputTree->Branch("Py_trueVis",&m_py_trueVis,"Py_trueVis/F");
+  m_outputTree->Branch("Pz_trueVis",&m_pz_trueVis,"Pz_trueVis/F");
 
-  //true particle level, only neutrinos
+  //true particle level, only neutrinos, true invisible content
   m_outputTree->Branch("E_trueInv" ,&m_E_trueInv, "E_trueInv/F");
   m_outputTree->Branch("Px_trueInv",&m_px_trueInv,"Px_trueInv/F");
   m_outputTree->Branch("Py_trueInv",&m_py_trueInv,"Py_trueInv/F");
@@ -214,10 +214,10 @@ void JetAnalyzer::processEvent( LCEvent* evt ) {
   m_py_trueInv = 0;
   m_pz_trueInv = 0;
 
-  m_E_trueAll  = 0;
-  m_px_trueAll = 0;
-  m_py_trueAll = 0;
-  m_pz_trueAll = 0;
+  m_E_trueVis  = 0;
+  m_px_trueVis = 0;
+  m_py_trueVis = 0;
+  m_pz_trueVis = 0;
 
   m_E_totPFO  = 0;
   m_px_totPFO = 0;
@@ -318,10 +318,10 @@ void JetAnalyzer::processEvent( LCEvent* evt ) {
       }
       if(mcp->getGeneratorStatus()==1){//visible sum of stable particles --> take neutrinos out
         if(abs(mcp->getPDG())!=12 && abs(mcp->getPDG())!=14 && abs(mcp->getPDG())!=16){
-          m_E_trueAll+=mcp->getEnergy();
-          m_px_trueAll+=mcp->getMomentum()[0];
-          m_py_trueAll+=mcp->getMomentum()[1];
-          m_pz_trueAll+=mcp->getMomentum()[2];
+          m_E_trueVis+=mcp->getEnergy();
+          m_px_trueVis+=mcp->getMomentum()[0];
+          m_py_trueVis+=mcp->getMomentum()[1];
+          m_pz_trueVis+=mcp->getMomentum()[2];
         }else{
           m_E_trueInv+=mcp->getEnergy();
           m_px_trueInv+=mcp->getMomentum()[0];

--- a/Calorimetry/src/JetAnalyzer.cc
+++ b/Calorimetry/src/JetAnalyzer.cc
@@ -1,0 +1,403 @@
+#include "JetAnalyzer.h"
+#include <UTIL/CellIDDecoder.h>
+#include <EVENT/LCCollection.h>
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCRelationImpl.h>
+#include <EVENT/CalorimeterHit.h>
+#include <EVENT/SimCalorimeterHit.h>
+
+#include "DD4hep/DD4hepUnits.h"
+#include "DD4hep/DetType.h"
+#include "DDRec/DetectorData.h"
+#include "DD4hep/DetectorSelector.h"
+
+#include "UTIL/LCRelationNavigator.h"
+
+#include "TFile.h"
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+JetAnalyzer aJetAnalyzer;
+
+JetAnalyzer::JetAnalyzer() : Processor("JetAnalyzer") {
+    
+    // modify processor description
+    _description = "JetAnalyzer calculates properties of calorimeter showers" ;
+   
+
+    registerInputCollection( LCIO::MCPARTICLE,
+                            "MCParticleCollectionName",
+                            "Name of the MCParticle input collection",
+                            m_inputMCParticleCollection,
+                            std::string("MCPhysicsParticles"));
+    
+    registerProcessorParameter( "OutputRootFileName",
+                                "ROOT File name to collect plots",
+                                m_rootFileName,
+                                std::string("JetAnalyzer.root"));
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                            "RECOParticleCollectionName",
+                            "Name of the RECOParticle input collection",
+                            m_inputRECOParticleCollection,
+                            std::string("PandoraPFOs"));
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+			     "GenJetCollection" ,  
+			     "Name of the GenJet collection"  ,
+			     m_genjetColName,
+			     std::string("GenJet_VLC")
+			     );
+
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+			     "RecoJetCollection" ,  
+			     "Name of the RecoJet collection"  ,
+			     m_recojetColName,
+			     std::string("RecoJet_VLC")
+			     );
+    registerProcessorParameter("doDiBosonChecks",
+			       "MC truth diboson checks for on-shell bosons",
+			       m_performDiBosonChecks,
+			       bool(false)
+			       );
+    registerProcessorParameter(
+			       "fillMEInfo" , 
+			       "save matrix element information",
+			       m_fillMEInfo,
+			       bool(false)			       
+			       );
+}  
+
+
+void JetAnalyzer::init() {
+
+  m_rootFile = new TFile(m_rootFileName.c_str(),"RECREATE");
+
+  m_outputTree = new TTree("showerData","showerData");
+
+  
+  // Print the initial parameters
+  printParameters() ;
+  
+  // Reset counters
+  m_runNumber = 0 ;
+  m_eventNumber = 0 ;
+
+  if(m_fillMEInfo){
+    m_trueME_E=new std::vector<float>();
+    m_trueME_Px=new std::vector<float>();
+    m_trueME_Py=new std::vector<float>();
+    m_trueME_Pz=new std::vector<float>();
+    m_trueME_PDGID=new std::vector<int>();
+  }
+
+  m_genJet_E   = new std::vector<float>(); 
+  m_genJet_Px  = new std::vector<float>(); 
+  m_genJet_Py  = new std::vector<float>(); 
+  m_genJet_Pz  = new std::vector<float>(); 
+
+  m_recoJet_E   = new std::vector<float>(); 
+  m_recoJet_Px  = new std::vector<float>(); 
+  m_recoJet_Py  = new std::vector<float>(); 
+  m_recoJet_Pz  = new std::vector<float>(); 
+
+  m_E_trueInv  = 0;
+  m_px_trueInv = 0;
+  m_py_trueInv = 0;
+  m_pz_trueInv = 0;
+
+  m_E_trueAll  = 0;
+  m_px_trueAll = 0;
+  m_py_trueAll = 0;
+  m_pz_trueAll = 0;
+
+  m_E_totPFO  = 0;
+  m_px_totPFO = 0;
+  m_py_totPFO = 0;
+  m_pz_totPFO = 0;
+
+  m_d1_mcPDGID = 0;
+  m_d1_mcE     = 0;
+  m_d1_mcPx    = 0;
+  m_d1_mcPy    = 0;
+  m_d1_mcPz    = 0;
+  
+  m_d2_mcPDGID = 0;
+  m_d2_mcE     = 0;
+  m_d2_mcPx    = 0;
+  m_d2_mcPy    = 0;
+  m_d2_mcPz    = 0;
+
+  m_genJet_E ->clear(); 
+  m_genJet_Px ->clear(); 
+  m_genJet_Py ->clear(); 
+  m_genJet_Pz ->clear(); 
+
+  m_recoJet_E ->clear(); 
+  m_recoJet_Px ->clear(); 
+  m_recoJet_Py ->clear(); 
+  m_recoJet_Pz ->clear(); 
+
+  if(m_fillMEInfo){
+    m_trueME_E->clear();
+    m_trueME_Px->clear();
+    m_trueME_Py->clear();
+    m_trueME_Pz->clear();
+    m_trueME_PDGID->clear();
+  }
+
+  if(m_fillMEInfo){
+    m_outputTree->Branch("trueME_Px", "std::vector< float >", &m_trueME_Px); 
+    m_outputTree->Branch("trueME_Py", "std::vector< float >", &m_trueME_Py); 
+    m_outputTree->Branch("trueME_Pz", "std::vector< float >", &m_trueME_Pz); 
+    m_outputTree->Branch("trueME_E", "std::vector< float >", &m_trueME_E); 
+    m_outputTree->Branch("trueME_PDGID", "std::vector< int >", &m_trueME_PDGID); 
+  }
+
+  m_outputTree->Branch("d1_mcPDGID",&m_d1_mcPDGID,"d1_mcPDGID/I");
+  m_outputTree->Branch("d1_mcE",&m_d1_mcE,"d1_mcE/F");
+  m_outputTree->Branch("d1_mcPx",&m_d1_mcPx,"d1_mcPx/F");
+  m_outputTree->Branch("d1_mcPy",&m_d1_mcPy,"d1_mcPy/F");
+  m_outputTree->Branch("d1_mcPz",&m_d1_mcPz,"d1_mcPz/F");
+  
+  m_outputTree->Branch("d2_mcPDGID",&m_d2_mcPDGID,"d2_mcPDGID/I");
+  m_outputTree->Branch("d2_mcE",&m_d2_mcE,"d2_mcE/F");
+  m_outputTree->Branch("d2_mcPx",&m_d2_mcPx,"d2_mcPx/F");
+  m_outputTree->Branch("d2_mcPy",&m_d2_mcPy,"d2_mcPy/F");
+  m_outputTree->Branch("d2_mcPz",&m_d2_mcPz,"d2_mcPz/F");
+
+  //true particle level, exclude neutrinos
+  m_outputTree->Branch("E_trueAll" ,&m_E_trueAll, "E_trueAll/F");
+  m_outputTree->Branch("Px_trueAll",&m_px_trueAll,"Px_trueAll/F");
+  m_outputTree->Branch("Py_trueAll",&m_py_trueAll,"Py_trueAll/F");
+  m_outputTree->Branch("Pz_trueAll",&m_pz_trueAll,"Pz_trueAll/F");
+
+  //true particle level, only neutrinos
+  m_outputTree->Branch("E_trueInv" ,&m_E_trueInv, "E_trueInv/F");
+  m_outputTree->Branch("Px_trueInv",&m_px_trueInv,"Px_trueInv/F");
+  m_outputTree->Branch("Py_trueInv",&m_py_trueInv,"Py_trueInv/F");
+  m_outputTree->Branch("Pz_trueInv",&m_pz_trueInv,"Pz_trueInv/F");
+  
+  //reconstructed leve
+  m_outputTree->Branch("E_totPFO" ,&m_E_totPFO, "E_totPFO/F");
+  m_outputTree->Branch("Px_totPFO",&m_px_totPFO,"Px_totPFO/F");
+  m_outputTree->Branch("Py_totPFO",&m_py_totPFO,"Py_totPFO/F");
+  m_outputTree->Branch("Pz_totPFO",&m_pz_totPFO,"Pz_totPFO/F");
+
+  m_outputTree->Branch("genJetE",  "std::vector< float >", &m_genJet_E); 
+  m_outputTree->Branch("genJetPx", "std::vector< float >", &m_genJet_Px); 
+  m_outputTree->Branch("genJetPy", "std::vector< float >", &m_genJet_Py); 
+  m_outputTree->Branch("genJetPz", "std::vector< float >", &m_genJet_Pz); 
+
+
+  m_outputTree->Branch("recoJetE",  "std::vector< float >", &m_recoJet_E); 
+  m_outputTree->Branch("recoJetPx", "std::vector< float >", &m_recoJet_Px); 
+  m_outputTree->Branch("recoJetPy", "std::vector< float >", &m_recoJet_Py); 
+  m_outputTree->Branch("recoJetPz", "std::vector< float >", &m_recoJet_Pz); 
+
+
+}
+
+
+void JetAnalyzer::processRunHeader( LCRunHeader*) {
+	++m_runNumber ;
+}
+
+void JetAnalyzer::processEvent( LCEvent* evt ) {
+
+  m_eventNumber=evt->getEventNumber();
+  m_runNumber=evt->getRunNumber();
+
+  m_E_trueInv  = 0;
+  m_px_trueInv = 0;
+  m_py_trueInv = 0;
+  m_pz_trueInv = 0;
+
+  m_E_trueAll  = 0;
+  m_px_trueAll = 0;
+  m_py_trueAll = 0;
+  m_pz_trueAll = 0;
+
+  m_E_totPFO  = 0;
+  m_px_totPFO = 0;
+  m_py_totPFO = 0;
+  m_pz_totPFO = 0;
+
+  m_d1_mcPDGID=-10;
+  m_d1_mcE=-10;
+  m_d1_mcPx=-10;
+  m_d1_mcPy=-10;
+  m_d1_mcPz=-10;
+  
+  m_d2_mcPDGID=-10;
+  m_d2_mcE=-10;
+  m_d2_mcPx=-10;
+  m_d2_mcPy=-10;
+  m_d2_mcPz=-10;
+
+  m_genJet_E ->clear(); 
+  m_genJet_Px ->clear(); 
+  m_genJet_Py ->clear(); 
+  m_genJet_Pz ->clear(); 
+
+  m_recoJet_E ->clear(); 
+  m_recoJet_Px ->clear(); 
+  m_recoJet_Py ->clear(); 
+  m_recoJet_Pz ->clear(); 
+
+
+  if(m_fillMEInfo){
+    m_trueME_E->clear();
+    m_trueME_Px->clear();
+    m_trueME_Py->clear();
+    m_trueME_Pz->clear();
+    m_trueME_PDGID->clear();
+  }
+
+
+  LCCollection * mcColl =0;
+  getCollection(mcColl,m_inputMCParticleCollection,evt);
+
+  bool pass_W_boson_mass=true;
+  bool pass_Z_boson_mass=true;
+  if(mcColl!=NULL){
+    int boson_counter=0;
+    int ind_second_boson=-1;
+    for(int m =0; m< mcColl->getNumberOfElements(); m++){
+      MCParticle* mcp= dynamic_cast<MCParticle*>( mcColl->getElementAt(m) ) ;
+      //boson checks have to be done for WW,WZ and ZZ configurations
+      if(m_performDiBosonChecks){
+	if(abs(mcp->getPDG())==24 || mcp->getPDG()==23){
+	  boson_counter+=1;
+	  if(abs(mcp->getPDG())==24 && boson_counter<3){
+	    if(fabs(mcp->getMass()-80.4)>20.0){
+	      pass_W_boson_mass=false;
+	    }
+	  }
+	  if(mcp->getPDG()==23 && boson_counter<3){
+	    if(fabs(mcp->getMass()-91.2)>20.0){
+	      pass_Z_boson_mass=false;
+	    }
+	  }
+	}
+      }
+      //first boson is the index immediately in front of the first boson
+      if(boson_counter==2 && pass_W_boson_mass && ind_second_boson==-1 && m_fillMEInfo){//for ZZ passed anyway, for WW or WZ passsed if real W
+	ind_second_boson=m;
+	MCParticle* mcp_1st= dynamic_cast<MCParticle*>( mcColl->getElementAt(ind_second_boson-1) ) ;
+	m_trueME_E->push_back(mcp_1st->getEnergy());
+	m_trueME_Px->push_back(mcp_1st->getMomentum()[0]);
+	m_trueME_Py->push_back(mcp_1st->getMomentum()[1]);
+	m_trueME_Pz->push_back(mcp_1st->getMomentum()[2]);
+	m_trueME_PDGID->push_back(mcp->getPDG());
+      }
+      //save all boson daughters
+      if(ind_second_boson>-1 && m<(ind_second_boson+5)){
+	m_trueME_E->push_back(mcp->getEnergy());
+	m_trueME_Px->push_back(mcp->getMomentum()[0]);
+	m_trueME_Py->push_back(mcp->getMomentum()[1]);
+	m_trueME_Pz->push_back(mcp->getMomentum()[2]);
+	m_trueME_PDGID->push_back(mcp->getPDG());
+      }
+      //fill first quark anti quark pair which appears in the history
+      //this IS the hadronic W and Z (in case of a mixed di-boson event)
+      if(abs(mcp->getPDG())<7 && m_d1_mcE<0) {
+	m_d1_mcPDGID=mcp->getPDG();
+	m_d1_mcE=mcp->getEnergy();
+	m_d1_mcPx=mcp->getMomentum()[0];
+	m_d1_mcPy=mcp->getMomentum()[1];
+	m_d1_mcPz=mcp->getMomentum()[2];
+      }
+      if(m_d2_mcE<0 && (abs(mcp->getPDG())<7 && mcp->getPDG()==(-m_d1_mcPDGID))){
+	m_d2_mcPDGID=mcp->getPDG();
+	m_d2_mcE=mcp->getEnergy();
+	m_d2_mcPx=mcp->getMomentum()[0];
+	m_d2_mcPy=mcp->getMomentum()[1];
+	m_d2_mcPz=mcp->getMomentum()[2];
+      }
+      if(mcp->getGeneratorStatus()==1){//visible sum of stable particles --> take neutrinos out
+	if(abs(mcp->getPDG())!=12 && abs(mcp->getPDG())!=14 &&  abs(mcp->getPDG())!=16){
+	  m_E_trueAll+=mcp->getEnergy();
+	  m_px_trueAll+=mcp->getMomentum()[0];
+	  m_py_trueAll+=mcp->getMomentum()[1];
+	  m_pz_trueAll+=mcp->getMomentum()[2];
+	}else{
+	  m_E_trueInv+=mcp->getEnergy();
+	  m_px_trueInv+=mcp->getMomentum()[0];
+	  m_py_trueInv+=mcp->getMomentum()[1];
+	  m_pz_trueInv+=mcp->getMomentum()[2];
+	}
+      }
+    }
+  }
+
+  LCCollection* recoparticlecol = NULL;
+  recoparticlecol = evt->getCollection(m_inputRECOParticleCollection) ;
+  if(recoparticlecol!=NULL){
+    //PandoraCandidate loop
+    for(int i=0;i<recoparticlecol->getNumberOfElements();i++){
+      ReconstructedParticle* pandorapart = dynamic_cast<ReconstructedParticle*>(recoparticlecol->getElementAt(i));
+      m_E_totPFO+=pandorapart->getEnergy();
+      m_px_totPFO+=pandorapart->getMomentum()[0];
+      m_py_totPFO+=pandorapart->getMomentum()[1];
+      m_pz_totPFO+=pandorapart->getMomentum()[2];
+    }
+  }
+
+  LCCollection* recojets = NULL;
+  recojets = evt->getCollection(m_recojetColName) ;
+  if(recojets!=NULL){
+    //PandoraCandidate loop
+    for(int i=0;i<recojets->getNumberOfElements();i++){
+      ReconstructedParticle* recojet = dynamic_cast<ReconstructedParticle*>(recojets->getElementAt(i));
+      m_recoJet_E->push_back(recojet->getEnergy());
+      m_recoJet_Px->push_back(recojet->getMomentum()[0]);
+      m_recoJet_Py->push_back(recojet->getMomentum()[1]);
+      m_recoJet_Pz->push_back(recojet->getMomentum()[2]);
+    }
+  }
+  LCCollection* genjets = NULL;
+  genjets = evt->getCollection(m_genjetColName) ;
+  if(genjets!=NULL){
+    //PandoraCandidate loop
+    for(int i=0;i<genjets->getNumberOfElements();i++){
+      ReconstructedParticle* genjet = dynamic_cast<ReconstructedParticle*>(genjets->getElementAt(i));
+      m_genJet_E->push_back(genjet->getEnergy());
+      m_genJet_Px->push_back(genjet->getMomentum()[0]);
+      m_genJet_Py->push_back(genjet->getMomentum()[1]);
+      m_genJet_Pz->push_back(genjet->getMomentum()[2]);
+    }
+  }
+
+  if(pass_W_boson_mass && pass_Z_boson_mass){
+    m_outputTree->Fill();
+  }
+}
+
+void JetAnalyzer::getCollection(LCCollection* &collection, std::string collectionName, LCEvent* evt){
+  try{
+    collection = evt->getCollection( collectionName ) ;
+  }
+  catch(DataNotAvailableException &e){
+    
+    streamlog_out( DEBUG5 )<<"- cannot get collection. Collection " << collectionName.c_str() << " is unavailable" << std::endl;
+    return;
+  }
+  return;
+}
+
+void JetAnalyzer::check(LCEvent*){
+}
+
+void JetAnalyzer::end(){
+    
+  m_rootFile->cd();  
+ 
+  m_rootFile->Write();
+  m_rootFile->Close();
+
+}
+

--- a/Calorimetry/src/JetAnalyzer.cc
+++ b/Calorimetry/src/JetAnalyzer.cc
@@ -22,53 +22,51 @@ using namespace marlin ;
 JetAnalyzer aJetAnalyzer;
 
 JetAnalyzer::JetAnalyzer() : Processor("JetAnalyzer") {
-    
-    // modify processor description
-    _description = "JetAnalyzer calculates properties of calorimeter showers" ;
+  
+  // modify processor description
+  _description = "JetAnalyzer calculates properties of calorimeter showers" ;
    
 
-    registerInputCollection( LCIO::MCPARTICLE,
-                            "MCParticleCollectionName",
-                            "Name of the MCParticle input collection",
-                            m_inputMCParticleCollection,
-                            std::string("MCPhysicsParticles"));
-    
-    registerProcessorParameter( "OutputRootFileName",
-                                "ROOT File name to collect plots",
-                                m_rootFileName,
-                                std::string("JetAnalyzer.root"));
+  registerInputCollection( LCIO::MCPARTICLE,
+              "MCParticleCollectionName",
+              "Name of the MCParticle input collection",
+              m_inputMCParticleCollection,
+              std::string("MCPhysicsParticles"));
+  
+  registerProcessorParameter( "OutputRootFileName",
+              "ROOT File name to collect plots",
+              m_rootFileName,
+              std::string("JetAnalyzer.root"));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "RECOParticleCollectionName",
-                            "Name of the RECOParticle input collection",
-                            m_inputRECOParticleCollection,
-                            std::string("PandoraPFOs"));
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+              "RECOParticleCollectionName",
+              "Name of the RECOParticle input collection",
+              m_inputRECOParticleCollection,
+              std::string("PandoraPFOs"));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-			     "GenJetCollection" ,  
-			     "Name of the GenJet collection"  ,
-			     m_genjetColName,
-			     std::string("GenJet_VLC")
-			     );
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+              "GenJetCollection" ,  
+              "Name of the GenJet collection",
+              m_genjetColName,
+              std::string("GenJet_VLC"));
 
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+              "RecoJetCollection" ,  
+              "Name of the RecoJet collection",
+              m_recojetColName,
+              std::string("RecoJet_VLC"));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-			     "RecoJetCollection" ,  
-			     "Name of the RecoJet collection"  ,
-			     m_recojetColName,
-			     std::string("RecoJet_VLC")
-			     );
-    registerProcessorParameter("doDiBosonChecks",
-			       "MC truth diboson checks for on-shell bosons",
-			       m_performDiBosonChecks,
-			       bool(false)
-			       );
-    registerProcessorParameter(
-			       "fillMEInfo" , 
-			       "save matrix element information",
-			       m_fillMEInfo,
-			       bool(false)			       
-			       );
+  registerProcessorParameter("doDiBosonChecks",
+              "MC truth diboson checks for on-shell bosons",
+              m_performDiBosonChecks,
+              bool(false));
+
+  registerProcessorParameter(
+              "fillMEInfo" , 
+              "save matrix element information",
+              m_fillMEInfo,
+              bool(false));
+
 }  
 
 
@@ -120,16 +118,16 @@ void JetAnalyzer::init() {
   m_pz_totPFO = 0;
 
   m_d1_mcPDGID = 0;
-  m_d1_mcE     = 0;
-  m_d1_mcPx    = 0;
-  m_d1_mcPy    = 0;
-  m_d1_mcPz    = 0;
+  m_d1_mcE   = 0;
+  m_d1_mcPx  = 0;
+  m_d1_mcPy  = 0;
+  m_d1_mcPz  = 0;
   
   m_d2_mcPDGID = 0;
-  m_d2_mcE     = 0;
-  m_d2_mcPx    = 0;
-  m_d2_mcPy    = 0;
-  m_d2_mcPz    = 0;
+  m_d2_mcE   = 0;
+  m_d2_mcPx  = 0;
+  m_d2_mcPy  = 0;
+  m_d2_mcPz  = 0;
 
   m_genJet_E ->clear(); 
   m_genJet_Px ->clear(); 
@@ -203,7 +201,7 @@ void JetAnalyzer::init() {
 
 
 void JetAnalyzer::processRunHeader( LCRunHeader*) {
-	++m_runNumber ;
+    ++m_runNumber ;
 }
 
 void JetAnalyzer::processEvent( LCEvent* evt ) {
@@ -263,73 +261,73 @@ void JetAnalyzer::processEvent( LCEvent* evt ) {
 
   bool pass_W_boson_mass=true;
   bool pass_Z_boson_mass=true;
-  if(mcColl!=NULL){
+    if(mcColl!=NULL){
     int boson_counter=0;
     int ind_second_boson=-1;
     for(int m =0; m< mcColl->getNumberOfElements(); m++){
       MCParticle* mcp= dynamic_cast<MCParticle*>( mcColl->getElementAt(m) ) ;
       //boson checks have to be done for WW,WZ and ZZ configurations
       if(m_performDiBosonChecks){
-	if(abs(mcp->getPDG())==24 || mcp->getPDG()==23){
-	  boson_counter+=1;
-	  if(abs(mcp->getPDG())==24 && boson_counter<3){
-	    if(fabs(mcp->getMass()-80.4)>20.0){
-	      pass_W_boson_mass=false;
-	    }
-	  }
-	  if(mcp->getPDG()==23 && boson_counter<3){
-	    if(fabs(mcp->getMass()-91.2)>20.0){
-	      pass_Z_boson_mass=false;
-	    }
-	  }
-	}
+        if(abs(mcp->getPDG())==24 || mcp->getPDG()==23){
+          boson_counter+=1;
+          if(abs(mcp->getPDG())==24 && boson_counter<3){
+            if(fabs(mcp->getMass()-80.4)>20.0){
+              pass_W_boson_mass=false;
+            }
+          }
+          if(mcp->getPDG()==23 && boson_counter<3){
+            if(fabs(mcp->getMass()-91.2)>20.0){
+              pass_Z_boson_mass=false;
+            }
+          }
+        }
       }
       //first boson is the index immediately in front of the first boson
       if(boson_counter==2 && pass_W_boson_mass && ind_second_boson==-1 && m_fillMEInfo){//for ZZ passed anyway, for WW or WZ passsed if real W
-	ind_second_boson=m;
-	MCParticle* mcp_1st= dynamic_cast<MCParticle*>( mcColl->getElementAt(ind_second_boson-1) ) ;
-	m_trueME_E->push_back(mcp_1st->getEnergy());
-	m_trueME_Px->push_back(mcp_1st->getMomentum()[0]);
-	m_trueME_Py->push_back(mcp_1st->getMomentum()[1]);
-	m_trueME_Pz->push_back(mcp_1st->getMomentum()[2]);
-	m_trueME_PDGID->push_back(mcp->getPDG());
+        ind_second_boson=m;
+        MCParticle* mcp_1st= dynamic_cast<MCParticle*>( mcColl->getElementAt(ind_second_boson-1) ) ;
+        m_trueME_E->push_back(mcp_1st->getEnergy());
+        m_trueME_Px->push_back(mcp_1st->getMomentum()[0]);
+        m_trueME_Py->push_back(mcp_1st->getMomentum()[1]);
+        m_trueME_Pz->push_back(mcp_1st->getMomentum()[2]);
+        m_trueME_PDGID->push_back(mcp->getPDG());
       }
       //save all boson daughters
       if(ind_second_boson>-1 && m<(ind_second_boson+5)){
-	m_trueME_E->push_back(mcp->getEnergy());
-	m_trueME_Px->push_back(mcp->getMomentum()[0]);
-	m_trueME_Py->push_back(mcp->getMomentum()[1]);
-	m_trueME_Pz->push_back(mcp->getMomentum()[2]);
-	m_trueME_PDGID->push_back(mcp->getPDG());
+        m_trueME_E->push_back(mcp->getEnergy());
+        m_trueME_Px->push_back(mcp->getMomentum()[0]);
+        m_trueME_Py->push_back(mcp->getMomentum()[1]);
+        m_trueME_Pz->push_back(mcp->getMomentum()[2]);
+        m_trueME_PDGID->push_back(mcp->getPDG());
       }
       //fill first quark anti quark pair which appears in the history
-      //this IS the hadronic W and Z (in case of a mixed di-boson event)
+    //this IS the hadronic W and Z (in case of a mixed di-boson event)
       if(abs(mcp->getPDG())<7 && m_d1_mcE<0) {
-	m_d1_mcPDGID=mcp->getPDG();
-	m_d1_mcE=mcp->getEnergy();
-	m_d1_mcPx=mcp->getMomentum()[0];
-	m_d1_mcPy=mcp->getMomentum()[1];
-	m_d1_mcPz=mcp->getMomentum()[2];
+        m_d1_mcPDGID=mcp->getPDG();
+        m_d1_mcE=mcp->getEnergy();
+        m_d1_mcPx=mcp->getMomentum()[0];
+        m_d1_mcPy=mcp->getMomentum()[1];
+        m_d1_mcPz=mcp->getMomentum()[2];
       }
       if(m_d2_mcE<0 && (abs(mcp->getPDG())<7 && mcp->getPDG()==(-m_d1_mcPDGID))){
-	m_d2_mcPDGID=mcp->getPDG();
-	m_d2_mcE=mcp->getEnergy();
-	m_d2_mcPx=mcp->getMomentum()[0];
-	m_d2_mcPy=mcp->getMomentum()[1];
-	m_d2_mcPz=mcp->getMomentum()[2];
+        m_d2_mcPDGID=mcp->getPDG();
+        m_d2_mcE=mcp->getEnergy();
+        m_d2_mcPx=mcp->getMomentum()[0];
+        m_d2_mcPy=mcp->getMomentum()[1];
+        m_d2_mcPz=mcp->getMomentum()[2];
       }
       if(mcp->getGeneratorStatus()==1){//visible sum of stable particles --> take neutrinos out
-	if(abs(mcp->getPDG())!=12 && abs(mcp->getPDG())!=14 &&  abs(mcp->getPDG())!=16){
-	  m_E_trueAll+=mcp->getEnergy();
-	  m_px_trueAll+=mcp->getMomentum()[0];
-	  m_py_trueAll+=mcp->getMomentum()[1];
-	  m_pz_trueAll+=mcp->getMomentum()[2];
-	}else{
-	  m_E_trueInv+=mcp->getEnergy();
-	  m_px_trueInv+=mcp->getMomentum()[0];
-	  m_py_trueInv+=mcp->getMomentum()[1];
-	  m_pz_trueInv+=mcp->getMomentum()[2];
-	}
+        if(abs(mcp->getPDG())!=12 && abs(mcp->getPDG())!=14 && abs(mcp->getPDG())!=16){
+          m_E_trueAll+=mcp->getEnergy();
+          m_px_trueAll+=mcp->getMomentum()[0];
+          m_py_trueAll+=mcp->getMomentum()[1];
+          m_pz_trueAll+=mcp->getMomentum()[2];
+        }else{
+          m_E_trueInv+=mcp->getEnergy();
+          m_px_trueInv+=mcp->getMomentum()[0];
+          m_py_trueInv+=mcp->getMomentum()[1];
+          m_pz_trueInv+=mcp->getMomentum()[2];
+        }
       }
     }
   }
@@ -382,7 +380,6 @@ void JetAnalyzer::getCollection(LCCollection* &collection, std::string collectio
     collection = evt->getCollection( collectionName ) ;
   }
   catch(DataNotAvailableException &e){
-    
     streamlog_out( DEBUG5 )<<"- cannot get collection. Collection " << collectionName.c_str() << " is unavailable" << std::endl;
     return;
   }
@@ -393,7 +390,7 @@ void JetAnalyzer::check(LCEvent*){
 }
 
 void JetAnalyzer::end(){
-    
+  
   m_rootFile->cd();  
  
   m_rootFile->Write();

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -100,7 +100,7 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
 	  }
 	  continue;
 	}
-	if(m_ignoreNeutrinosInMCJets && fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16){
+	if(m_ignoreNeutrinosInMCJets && (fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16)){
 	  continue;
 	}
 	ReconstructedParticleImpl* truePartIntoReco = new ReconstructedParticleImpl;

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -14,6 +14,7 @@ using namespace marlin ;
 
 TrueMCintoRecoForJets aTrueMCintoRecoForJets;
 
+
 TrueMCintoRecoForJets::TrueMCintoRecoForJets() : Processor("TrueMCintoRecoForJets") {
   
     // modify processor description
@@ -46,8 +47,9 @@ TrueMCintoRecoForJets::TrueMCintoRecoForJets() : Processor("TrueMCintoRecoForJet
 			       "remove neutrinos prior to MC Jet Clustering",
 			       m_ignoreNeutrinosInMCJets,
 			       bool(true));
+
     registerProcessorParameter("cosAngle_pfo_lepton",
-			       "remove neutrinos prior to MC Jet Clustering",
+			       "matching angle between PFOs and MC leptons from vector bosons",
 			       m_cosAngle_pfo_lepton,
 			       float(0.995));
 
@@ -101,10 +103,11 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
 	if (boson_daughtersFunc.count(mcp) != 0)
 	{
 	  if(ind_MCLep==-1 && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
-	    ind_MCLep=m;	   
+	    ind_MCLep=m;	  
 	  }
-	  if(ind_MCLep2==-1 && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
-	    ind_MCLep2=m;	   
+	  //only check for second lepton in case it is not already the first lepton
+	  if((ind_MCLep!=m && ind_MCLep2==-1) && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
+	    ind_MCLep2=m;
 	  }
 	  continue;
 	}

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -42,6 +42,11 @@ TrueMCintoRecoForJets::TrueMCintoRecoForJets() : Processor("TrueMCintoRecoForJet
 			       m_vetoBosonLeptonsOnReco,
 			       bool("false"));
 
+    registerProcessorParameter("ignoreNeutrinosInMCJets",
+			       "remove neutrinos prior to MC Jet Clustering",
+			       m_ignoreNeutrinosInMCJets,
+			       bool("true"));
+
     registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
                             "RecoParticleInputCollectionName",
                             "Name of the RecoParticle input collection",
@@ -95,7 +100,7 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
 	  }
 	  continue;
 	}
-	if(fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16){
+	if(m_ignoreNeutrinosInMCJets && fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16){
 	  continue;
 	}
 	ReconstructedParticleImpl* truePartIntoReco = new ReconstructedParticleImpl;

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -87,7 +87,7 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
       for(int m=0;m<nMCP;m++){
 	MCParticle *mcp = static_cast<MCParticle*>(mcColl->getElementAt(m));
 	//in order to catch events where the lepton branches off an FSR photon
-	if(m_vetoBosonLeptons && abs(mcp->getPDG())==24 && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
+	if(m_vetoBosonLeptons && (abs(mcp->getPDG())==24 || mcp->getPDG()==23) && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
 	  fillStableDaughterSet(mcp, boson_daughtersFunc);
 	}
 	if(mcp->getGeneratorStatus()!=1){

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -1,0 +1,177 @@
+#include "TrueMCintoRecoForJets.h"
+#include <EVENT/LCCollection.h>
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/ReconstructedParticleImpl.h>
+
+#include "DDRec/DetectorData.h"
+
+#include "TLorentzVector.h"
+
+using namespace lcio ;
+using namespace marlin ;
+
+
+TrueMCintoRecoForJets aTrueMCintoRecoForJets;
+
+TrueMCintoRecoForJets::TrueMCintoRecoForJets() : Processor("TrueMCintoRecoForJets") {
+  
+    // modify processor description
+    _description = "TrueMCintoRecoForJets calculates properties of calorimeter showers" ;
+   
+
+    registerInputCollection( LCIO::MCPARTICLE,
+                            "MCParticleInputCollectionName",
+                            "Name of the MCParticle input collection",
+                            m_inputMCParticleCollection,
+                            std::string("MCPhysicsParticles"));
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                            "RECOParticleCollectionName",
+                            "Name of the RECOParticle output collection",
+                            m_outputRECOParticleCollection,
+                            std::string("MCParticlePandoraPFOs"));
+
+    registerProcessorParameter("vetoBosonLeptons",
+			       "leptons from boson veto flag for MC truth",
+			       m_vetoBosonLeptons,
+			       bool("false"));
+
+    registerProcessorParameter("vetoBosonLeptonsOnReco",
+			       "leptons from boson veto flag for Reco",
+			       m_vetoBosonLeptonsOnReco,
+			       bool("false"));
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                            "RecoParticleInputCollectionName",
+                            "Name of the RecoParticle input collection",
+                            m_inputRecoParticleCollection,
+                            std::string("TightSelectedPandoraPFOs"));
+
+    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                            "RecoParticleNoLeptonCollectionName",
+                            "Name of the RecoParticleNoLepton output collection",
+			     m_outputRecoNoLepParticleCollection,
+                            std::string("PandoraPFOsNoLeptons"));
+  
+}  
+
+
+void TrueMCintoRecoForJets::init() {
+}
+
+
+void TrueMCintoRecoForJets::processRunHeader( LCRunHeader*) {
+
+}
+
+void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
+  
+    LCCollection * mcColl =0;
+    getCollection(mcColl,m_inputMCParticleCollection,evt);
+    LCCollectionVec *reccolForJets = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    LCCollectionVec *reccolNoLep = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+    
+    if( mcColl != 0 ){
+      int nMCP = mcColl->getNumberOfElements();
+      
+      std::set<MCParticle*> boson_daughtersFunc;
+ 
+      int ind_MCLep=-1;
+
+      for(int m=0;m<nMCP;m++){
+	MCParticle *mcp = static_cast<MCParticle*>(mcColl->getElementAt(m));
+	//in order to catch events where the lepton branches off an FSR photon
+	if(m_vetoBosonLeptons && abs(mcp->getPDG())==24 && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
+	  fillStableDaughterSet(mcp, boson_daughtersFunc);
+	}
+	if(mcp->getGeneratorStatus()!=1){
+	  continue;
+	}
+	if (boson_daughtersFunc.count(mcp) != 0)
+	{
+	  if(abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13){
+	    ind_MCLep=m;	   
+	  }
+	  continue;
+	}
+	if(fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16){
+	  continue;
+	}
+	ReconstructedParticleImpl* truePartIntoReco = new ReconstructedParticleImpl;
+	truePartIntoReco->setMomentum(mcp->getMomentum());
+	truePartIntoReco->setType(mcp->getPDG());
+	truePartIntoReco->setEnergy(mcp->getEnergy());
+	truePartIntoReco->setMass(mcp->getMass());
+	truePartIntoReco->setCharge(mcp->getCharge());
+	reccolForJets->addElement(truePartIntoReco); 
+      }
+
+      
+      LCCollection * recoColl =0;
+      getCollection(recoColl,m_inputRecoParticleCollection,evt);
+      int nReco = recoColl->getNumberOfElements();
+      for(int r=0;r<nReco;r++){
+	ReconstructedParticle *reco = static_cast<ReconstructedParticle*>(recoColl->getElementAt(r));
+	if( ind_MCLep!=-1){
+	  MCParticle *mcpLep = static_cast<MCParticle*>(mcColl->getElementAt(ind_MCLep));
+	  TLorentzVector trueLep(0,0,0,0);
+	  trueLep.SetPxPyPzE(mcpLep->getMomentum()[0],mcpLep->getMomentum()[1],mcpLep->getMomentum()[2],mcpLep->getEnergy());	   
+	  //we don't want to check lepton reconstruction/lepton finders
+	  //veto particles close to the true lepton from the bosons, ignore tau's for now
+	  //take true MC lepton direction, veto all reconstructed particles around that direction within acos(alpha)>0.90
+	  TLorentzVector recoVec(0,0,0,0);
+	  recoVec.SetPxPyPzE(reco->getMomentum()[0],reco->getMomentum()[1],reco->getMomentum()[2],reco->getEnergy());
+	  if(cos(recoVec.Angle(trueLep.Vect()))>0.9 && m_vetoBosonLeptonsOnReco){
+	    continue;
+	  }
+	}
+	ReconstructedParticleImpl* recoNoLep = new ReconstructedParticleImpl;
+	recoNoLep->setMomentum(reco->getMomentum());
+	recoNoLep->setEnergy(reco->getEnergy());
+	recoNoLep->setType(reco->getType());
+	recoNoLep->setCovMatrix(reco->getCovMatrix());
+	recoNoLep->setMass(reco->getMass());
+	recoNoLep->setCharge(reco->getCharge());
+	recoNoLep->setParticleIDUsed(reco->getParticleIDUsed());
+	recoNoLep->setGoodnessOfPID(reco->getGoodnessOfPID());
+	recoNoLep->setStartVertex(reco->getStartVertex());
+	reccolNoLep->addElement(recoNoLep); 
+      }
+    }
+    
+    evt->addCollection(reccolNoLep,m_outputRecoNoLepParticleCollection);
+    evt->addCollection(reccolForJets,m_outputRECOParticleCollection);
+    
+}
+
+void TrueMCintoRecoForJets::fillStableDaughterSet(MCParticle* mcp, std::set<MCParticle*> &stableDaughterSet){
+  if(mcp->getGeneratorStatus()==1){
+    stableDaughterSet.insert(mcp);
+  }else if (mcp->getGeneratorStatus()==0){
+    return;
+  }
+  for(unsigned int d=0;d<mcp->getDaughters().size();d++){
+    fillStableDaughterSet(mcp->getDaughters()[d], stableDaughterSet);
+  }
+}
+
+void TrueMCintoRecoForJets::check(LCEvent*){
+}
+
+void TrueMCintoRecoForJets::end(){
+
+}
+
+
+void TrueMCintoRecoForJets::getCollection(LCCollection* &collection, std::string collectionName, LCEvent* evt){
+  try{
+    collection = evt->getCollection( collectionName ) ;
+  }
+  catch(DataNotAvailableException &e){
+    
+    streamlog_out( DEBUG5 )<<"- cannot get collection. Collection " << collectionName.c_str() << " is unavailable" << std::endl;
+    return;
+  }
+  return;
+}

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -100,6 +100,7 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
     MCParticle *mcp = static_cast<MCParticle*>(mcColl->getElementAt(m));
     //in order to catch events where the lepton branches off an FSR photon
     if(m_vetoBosonLeptons && (abs(mcp->getPDG())==24 || mcp->getPDG()==23) && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
+      //fill for lepton decays (e,mu,tau, and corresponding neutrinos)
       fillStableDaughterSet(mcp, boson_daughtersFunc);
     }
     if(mcp->getGeneratorStatus()!=1){
@@ -107,6 +108,7 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
     }
     if (boson_daughtersFunc.count(mcp) != 0)
       {
+	//check for muon and electrons in decay history, catches also leptonic tau decays
         if(ind_MCLep==-1 && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
           ind_MCLep=m;  
         }

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -168,10 +168,13 @@ void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
 	reccolNoLep->addElement(recoNoLep); 
       }
     }
-    
-    evt->addCollection(reccolNoLep,m_outputRecoNoLepParticleCollection);
-    evt->addCollection(reccolForJets,m_outputRECOParticleCollection);
-    
+    if( mcColl != 0 ){
+      evt->addCollection(reccolNoLep,m_outputRecoNoLepParticleCollection);
+      evt->addCollection(reccolForJets,m_outputRECOParticleCollection);
+      if( mcColl == nullptr ){
+	return;
+      }
+    }
 }
 
 void TrueMCintoRecoForJets::fillStableDaughterSet(MCParticle* mcp, std::set<MCParticle*> &stableDaughterSet){

--- a/Calorimetry/src/TrueMCintoRecoForJets.cc
+++ b/Calorimetry/src/TrueMCintoRecoForJets.cc
@@ -17,53 +17,53 @@ TrueMCintoRecoForJets aTrueMCintoRecoForJets;
 
 TrueMCintoRecoForJets::TrueMCintoRecoForJets() : Processor("TrueMCintoRecoForJets") {
   
-    // modify processor description
-    _description = "TrueMCintoRecoForJets calculates properties of calorimeter showers" ;
+  // modify processor description
+  _description = "TrueMCintoRecoForJets calculates properties of calorimeter showers" ;
    
 
-    registerInputCollection( LCIO::MCPARTICLE,
-                            "MCParticleInputCollectionName",
-                            "Name of the MCParticle input collection",
-                            m_inputMCParticleCollection,
-                            std::string("MCPhysicsParticles"));
+  registerInputCollection( LCIO::MCPARTICLE,
+                           "MCParticleInputCollectionName",
+                           "Name of the MCParticle input collection",
+                           m_inputMCParticleCollection,
+                           std::string("MCPhysicsParticles"));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "RECOParticleCollectionName",
-                            "Name of the RECOParticle output collection",
-                            m_outputRECOParticleCollection,
-                            std::string("MCParticlePandoraPFOs"));
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "RECOParticleCollectionName",
+                           "Name of the RECOParticle output collection",
+                           m_outputRECOParticleCollection,
+                           std::string("MCParticlePandoraPFOs"));
 
-    registerProcessorParameter("vetoBosonLeptons",
-			       "leptons from boson veto flag for MC truth",
-			       m_vetoBosonLeptons,
-			       bool(false));
+  registerProcessorParameter("vetoBosonLeptons",
+                           "leptons from boson veto flag for MC truth",
+                           m_vetoBosonLeptons,
+                           bool(false));
 
-    registerProcessorParameter("vetoBosonLeptonsOnReco",
-			       "leptons from boson veto flag for Reco",
-			       m_vetoBosonLeptonsOnReco,
-			       bool(false));
+  registerProcessorParameter("vetoBosonLeptonsOnReco",
+                           "leptons from boson veto flag for Reco",
+                           m_vetoBosonLeptonsOnReco,
+                           bool(false));
 
-    registerProcessorParameter("ignoreNeutrinosInMCJets",
-			       "remove neutrinos prior to MC Jet Clustering",
-			       m_ignoreNeutrinosInMCJets,
-			       bool(true));
+  registerProcessorParameter("ignoreNeutrinosInMCJets",
+                           "remove neutrinos prior to MC Jet Clustering",
+                           m_ignoreNeutrinosInMCJets,
+                           bool(true));
 
-    registerProcessorParameter("cosAngle_pfo_lepton",
-			       "matching angle between PFOs and MC leptons from vector bosons",
-			       m_cosAngle_pfo_lepton,
-			       float(0.995));
+  registerProcessorParameter("cosAngle_pfo_lepton",
+                           "matching angle between PFOs and MC leptons from vector bosons",
+                           m_cosAngle_pfo_lepton,
+                           float(0.995));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "RecoParticleInputCollectionName",
-                            "Name of the RecoParticle input collection",
-                            m_inputRecoParticleCollection,
-                            std::string("TightSelectedPandoraPFOs"));
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "RecoParticleInputCollectionName",
+                           "Name of the RecoParticle input collection",
+                           m_inputRecoParticleCollection,
+                           std::string("TightSelectedPandoraPFOs"));
 
-    registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "RecoParticleNoLeptonCollectionName",
-                            "Name of the RecoParticleNoLepton output collection",
-			     m_outputRecoNoLepParticleCollection,
-                            std::string("PandoraPFOsNoLeptons"));
+  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
+                           "RecoParticleNoLeptonCollectionName",
+                           "Name of the RecoParticleNoLepton output collection",
+                           m_outputRecoNoLepParticleCollection,
+                           std::string("PandoraPFOsNoLeptons"));
   
 }  
 
@@ -78,100 +78,100 @@ void TrueMCintoRecoForJets::processRunHeader( LCRunHeader*) {
 
 void TrueMCintoRecoForJets::processEvent( LCEvent* evt ) {
   
-    LCCollection * mcColl =0;
-    getCollection(mcColl,m_inputMCParticleCollection,evt);
-    LCCollectionVec *reccolForJets = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    LCCollectionVec *reccolNoLep = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
-    
+  LCCollection * mcColl =0;
+  getCollection(mcColl,m_inputMCParticleCollection,evt);
+  LCCollectionVec *reccolForJets = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  LCCollectionVec *reccolNoLep = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
+  
 
-    evt->addCollection(reccolNoLep,m_outputRecoNoLepParticleCollection);
-    evt->addCollection(reccolForJets,m_outputRECOParticleCollection);
-    if( mcColl == nullptr ){
-      return;
+  evt->addCollection(reccolNoLep,m_outputRecoNoLepParticleCollection);
+  evt->addCollection(reccolForJets,m_outputRECOParticleCollection);
+  if( mcColl == nullptr ){
+  return;
+  }
+  int nMCP = mcColl->getNumberOfElements();
+  
+  std::set<MCParticle*> boson_daughtersFunc;
+  
+  int ind_MCLep=-1;//semi leptonically decaying W-lepton (e,mu), or first lepton (e,mu) for Z
+  int ind_MCLep2=-1;// in case of Z second lepton (e,mu)
+  
+  for(int m=0;m<nMCP;m++){
+    MCParticle *mcp = static_cast<MCParticle*>(mcColl->getElementAt(m));
+    //in order to catch events where the lepton branches off an FSR photon
+    if(m_vetoBosonLeptons && (abs(mcp->getPDG())==24 || mcp->getPDG()==23) && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
+      fillStableDaughterSet(mcp, boson_daughtersFunc);
     }
-    int nMCP = mcColl->getNumberOfElements();
-    
-    std::set<MCParticle*> boson_daughtersFunc;
-    
-    int ind_MCLep=-1;//semi leptonically decaying W-lepton (e,mu), or first lepton (e,mu) for Z
-    int ind_MCLep2=-1;// in case of Z second lepton (e,mu)
-    
-    for(int m=0;m<nMCP;m++){
-      MCParticle *mcp = static_cast<MCParticle*>(mcColl->getElementAt(m));
-      //in order to catch events where the lepton branches off an FSR photon
-      if(m_vetoBosonLeptons && (abs(mcp->getPDG())==24 || mcp->getPDG()==23) && mcp->getDaughters().size()>1 && (abs(mcp->getDaughters()[0]->getPDG())>6 && abs(mcp->getDaughters()[0]->getPDG())<17)){
-	fillStableDaughterSet(mcp, boson_daughtersFunc);
-      }
-      if(mcp->getGeneratorStatus()!=1){
-	continue;
-      }
-      if (boson_daughtersFunc.count(mcp) != 0)
-	{
-	  if(ind_MCLep==-1 && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
-	    ind_MCLep=m;	  
-	  }
-	  //only check for second lepton in case it is not already the first lepton
-	  if((ind_MCLep!=m && ind_MCLep2==-1) && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
-	    ind_MCLep2=m;
-	  }
-	  continue;
-	}
-      if(m_ignoreNeutrinosInMCJets && (fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16)){
-	continue;
-      }
-      ReconstructedParticleImpl* truePartIntoReco = new ReconstructedParticleImpl;
-      truePartIntoReco->setMomentum(mcp->getMomentum());
-      truePartIntoReco->setType(mcp->getPDG());
-      truePartIntoReco->setEnergy(mcp->getEnergy());
-      truePartIntoReco->setMass(mcp->getMass());
-      truePartIntoReco->setCharge(mcp->getCharge());
-      reccolForJets->addElement(truePartIntoReco); 
+    if(mcp->getGeneratorStatus()!=1){
+      continue;
     }
+    if (boson_daughtersFunc.count(mcp) != 0)
+      {
+        if(ind_MCLep==-1 && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
+          ind_MCLep=m;  
+        }
+        //only check for second lepton in case it is not already the first lepton
+        if((ind_MCLep!=m && ind_MCLep2==-1) && (abs(mcp->getPDG())==11 || abs(mcp->getPDG())==13)){
+          ind_MCLep2=m;
+        }
+        continue;
+      }
+    if(m_ignoreNeutrinosInMCJets && (fabs(mcp->getPDG())==12 || fabs(mcp->getPDG())==14 || fabs(mcp->getPDG())==16)){
+      continue;
+    }
+    ReconstructedParticleImpl* truePartIntoReco = new ReconstructedParticleImpl;
+    truePartIntoReco->setMomentum(mcp->getMomentum());
+    truePartIntoReco->setType(mcp->getPDG());
+    truePartIntoReco->setEnergy(mcp->getEnergy());
+    truePartIntoReco->setMass(mcp->getMass());
+    truePartIntoReco->setCharge(mcp->getCharge());
+    reccolForJets->addElement(truePartIntoReco); 
+  }
     
       
-    LCCollection * recoColl =0;
-    getCollection(recoColl,m_inputRecoParticleCollection,evt);
-    int nReco = recoColl->getNumberOfElements();
-    for(int r=0;r<nReco;r++){
-      ReconstructedParticle *reco = static_cast<ReconstructedParticle*>(recoColl->getElementAt(r));
-      if( ind_MCLep!=-1){
-	MCParticle *mcpLep = static_cast<MCParticle*>(mcColl->getElementAt(ind_MCLep));
-	TLorentzVector trueLep(0,0,0,0);
-	trueLep.SetPxPyPzE(mcpLep->getMomentum()[0],mcpLep->getMomentum()[1],mcpLep->getMomentum()[2],mcpLep->getEnergy());	   
-	//we don't want to check lepton reconstruction/lepton finders
-	//veto particles close to the true lepton from the bosons, ignore tau's for now
-	//take true MC lepton direction, veto all reconstructed particles around that direction within acos(alpha)>0.90
-	TLorentzVector recoVec(0,0,0,0);
-	recoVec.SetPxPyPzE(reco->getMomentum()[0],reco->getMomentum()[1],reco->getMomentum()[2],reco->getEnergy());
-	if(cos(recoVec.Angle(trueLep.Vect()))>m_cosAngle_pfo_lepton && m_vetoBosonLeptonsOnReco){
-	  continue;
-	}
+  LCCollection * recoColl =0;
+  getCollection(recoColl,m_inputRecoParticleCollection,evt);
+  int nReco = recoColl->getNumberOfElements();
+  for(int r=0;r<nReco;r++){
+    ReconstructedParticle *reco = static_cast<ReconstructedParticle*>(recoColl->getElementAt(r));
+    if( ind_MCLep!=-1){
+      MCParticle *mcpLep = static_cast<MCParticle*>(mcColl->getElementAt(ind_MCLep));
+      TLorentzVector trueLep(0,0,0,0);
+      trueLep.SetPxPyPzE(mcpLep->getMomentum()[0],mcpLep->getMomentum()[1],mcpLep->getMomentum()[2],mcpLep->getEnergy());          
+      //we don't want to check lepton reconstruction/lepton finders
+      //veto particles close to the true lepton from the bosons, ignore tau's for now
+      //take true MC lepton direction, veto all reconstructed particles around that direction within acos(alpha)>0.90
+      TLorentzVector recoVec(0,0,0,0);
+      recoVec.SetPxPyPzE(reco->getMomentum()[0],reco->getMomentum()[1],reco->getMomentum()[2],reco->getEnergy());
+      if(cos(recoVec.Angle(trueLep.Vect()))>m_cosAngle_pfo_lepton && m_vetoBosonLeptonsOnReco){
+        continue;
       }
-      if( ind_MCLep2!=-1){
-	MCParticle *mcpLep2 = static_cast<MCParticle*>(mcColl->getElementAt(ind_MCLep2));
-	TLorentzVector trueLep2(0,0,0,0);
-	trueLep2.SetPxPyPzE(mcpLep2->getMomentum()[0],mcpLep2->getMomentum()[1],mcpLep2->getMomentum()[2],mcpLep2->getEnergy());	   
-	//we don't want to check lepton reconstruction/lepton finders
-	//veto particles close to the true lepton from the bosons, ignore tau's for now
-	//take true MC lepton direction, veto all reconstructed particles around that direction within acos(alpha)>0.90
-	TLorentzVector recoVec(0,0,0,0);
-	recoVec.SetPxPyPzE(reco->getMomentum()[0],reco->getMomentum()[1],reco->getMomentum()[2],reco->getEnergy());
-	if(cos(recoVec.Angle(trueLep2.Vect()))>m_cosAngle_pfo_lepton && m_vetoBosonLeptonsOnReco){
-	  continue;
-	}
-      }
-      ReconstructedParticleImpl* recoNoLep = new ReconstructedParticleImpl;
-      recoNoLep->setMomentum(reco->getMomentum());
-      recoNoLep->setEnergy(reco->getEnergy());
-      recoNoLep->setType(reco->getType());
-      recoNoLep->setCovMatrix(reco->getCovMatrix());
-      recoNoLep->setMass(reco->getMass());
-      recoNoLep->setCharge(reco->getCharge());
-      recoNoLep->setParticleIDUsed(reco->getParticleIDUsed());
-      recoNoLep->setGoodnessOfPID(reco->getGoodnessOfPID());
-      recoNoLep->setStartVertex(reco->getStartVertex());
-      reccolNoLep->addElement(recoNoLep); 
     }
+    if( ind_MCLep2!=-1){
+      MCParticle *mcpLep2 = static_cast<MCParticle*>(mcColl->getElementAt(ind_MCLep2));
+      TLorentzVector trueLep2(0,0,0,0);
+      trueLep2.SetPxPyPzE(mcpLep2->getMomentum()[0],mcpLep2->getMomentum()[1],mcpLep2->getMomentum()[2],mcpLep2->getEnergy());     
+      //we don't want to check lepton reconstruction/lepton finders
+      //veto particles close to the true lepton from the bosons, ignore tau's for now
+      //take true MC lepton direction, veto all reconstructed particles around that direction within acos(alpha)>0.90
+      TLorentzVector recoVec(0,0,0,0);
+      recoVec.SetPxPyPzE(reco->getMomentum()[0],reco->getMomentum()[1],reco->getMomentum()[2],reco->getEnergy());
+      if(cos(recoVec.Angle(trueLep2.Vect()))>m_cosAngle_pfo_lepton && m_vetoBosonLeptonsOnReco){
+        continue;
+      }
+    }
+    ReconstructedParticleImpl* recoNoLep = new ReconstructedParticleImpl;
+    recoNoLep->setMomentum(reco->getMomentum());
+    recoNoLep->setEnergy(reco->getEnergy());
+    recoNoLep->setType(reco->getType());
+    recoNoLep->setCovMatrix(reco->getCovMatrix());
+    recoNoLep->setMass(reco->getMass());
+    recoNoLep->setCharge(reco->getCharge());
+    recoNoLep->setParticleIDUsed(reco->getParticleIDUsed());
+    recoNoLep->setGoodnessOfPID(reco->getGoodnessOfPID());
+    recoNoLep->setStartVertex(reco->getStartVertex());
+    reccolNoLep->addElement(recoNoLep); 
+  }
     
 }
 
@@ -199,7 +199,7 @@ void TrueMCintoRecoForJets::getCollection(LCCollection* &collection, std::string
     collection = evt->getCollection( collectionName ) ;
   }
   catch(DataNotAvailableException &e){
-    
+  
     streamlog_out( DEBUG5 )<<"- cannot get collection. Collection " << collectionName.c_str() << " is unavailable" << std::endl;
     return;
   }

--- a/Calorimetry/testCalibJetStudies.xml
+++ b/Calorimetry/testCalibJetStudies.xml
@@ -32,7 +32,7 @@
   <parameter name="fillMEInfo" type="bool">false</parameter>
   <!--check on MC truth for on-shell bosons-->
   <parameter name="doDiBosonChecks" type="bool">false</parameter>
-  <parameter name="OutputRootFileName" type="string">JetStudy_WW1000_11814_CLIC_o3_v14_CT_TightSelectedPandoraPFOs_withbosoncheck_fillMCHistory_RecoLepVeto_noNeutrinoVetoOfAll_VBosonLepVeto.root
+  <parameter name="OutputRootFileName" type="string">JetStudy_WW1000_11814_CLIC_o3_v14_CT_TightSelectedPandoraPFOs_testnew.root
   </parameter>
 </processor>
 

--- a/Calorimetry/testCalibJetStudies.xml
+++ b/Calorimetry/testCalibJetStudies.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<!-- ?xml-stylesheet type="text/xsl" href="http://ilcsoft.desy.de/marlin/marlin.xsl"? -->
+<!-- ?xml-stylesheet type="text/xsl" href="marlin.xsl"? -->
+
+<!-- Loading shared library : /scratch1/DD4hepDetCalibration/ClicPerformance/lib/libClicPerformance.so.1.0.0 (libClicPerformance.so)-->
+
+<!--##########################################
+    #                                        #
+    #     Example steering file for marlin   #
+    #                                        #
+    ##########################################-->
+
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+ <execute>
+   <processor name="MyTrueMCintoRecoForJets"/>     
+   <processor name="MyFastGenJetProcessor"/>  
+   <processor name="MyFastRecoJetProcessor"/>  
+   <processor name="MyJetAnalyzer"/>
+ </execute>
+
+<processor name="MyJetAnalyzer" type="JetAnalyzer">
+  <!--Reco particles, include also isolated leptons here, should be of same type as the one used as jet clusteringg input-->
+  <parameter name="RECOParticleCollectionName" type="string" lcioInType="ReconstructedParticle">TightSelectedPandoraPFOs</parameter>
+  <!--Name of the MCParticle input collection, also considers isolated leptons and neutrinos-->
+  <parameter name="MCParticleCollectionName" type="string" lcioInType="McParticle">MCPhysicsParticles</parameter>
+  <!--Name of the GenJet input collection-->
+  <parameter name="GenJetCollection" type="string" lcioInType="ReconstructedParticle">GenJet_VLC</parameter>
+  <!--Name of the RecoJet input collection-->
+  <parameter name="RecoJetCollection" type="string" lcioInType="ReconstructedParticle">RecoJet_VLC</parameter>
+  <!--flag to fill all first MC particles in decay chain, saves di-boson decay-->
+  <parameter name="fillMEInfo" type="bool">false</parameter>
+  <!--check on MC truth for on-shell bosons-->
+  <parameter name="doDiBosonChecks" type="bool">false</parameter>
+  <parameter name="OutputRootFileName" type="string">JetStudy_WW1000_11814_CLIC_o3_v14_CT_TightSelectedPandoraPFOs_withbosoncheck_fillMCHistory_RecoLepVeto_noNeutrinoVetoOfAll_VBosonLepVeto.root
+  </parameter>
+</processor>
+
+<global>
+  <parameter name="LCIOInputFiles">
+/eos/experiment/clicdp/grid/ilc/prod/clic/1tev/WW/CLIC_o3_v14/DST/00011814/000/WW_dst_11814_1.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/1tev/WW/CLIC_o3_v14/DST/00011814/000/WW_dst_11814_2.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/1tev/WW/CLIC_o3_v14/DST/00011814/000/WW_dst_11814_3.slcio /eos/experiment/clicdp/grid/ilc/prod/clic/1tev/WW/CLIC_o3_v14/DST/00011814/000/WW_dst_11814_4.slcio
+  </parameter>
+  <!-- limit the number of processed records (run+evt): -->  
+  <parameter name="MaxRecordNumber" value="-1"/>   
+  <parameter name="SkipNEvents" value="0" />  
+  <parameter name="SupressCheck" value="false" />  
+  <parameter name="AllowToModifyEvent" value="false" />  
+  <!--<parameter name="GearXMLFile"> /afs/cern.h/user/w/weberma2/public/CLIC_o3_v08_gear.xml </parameter>  -->
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING  </parameter> 
+  <parameter name="RandomSeed" value="1234567890" />
+  <!-- optionally limit the collections that are read from the input file: -->  
+  <!--parameter name="LCIOReadCollectionNames">MCParticle PandoraPFOs</parameter-->
+ </global>
+
+<processor name="MyTrueMCintoRecoForJets" type="TrueMCintoRecoForJets">
+  <!--name of the pseudo RecoParticleCollection made from MCParticles-->
+  <parameter name="RECOParticleCollectionName" type="string" lcioInType="ReconstructedParticle">MCParticlePandoraPFOs</parameter>
+  <!--Name of the MCParticle input collection-->
+  <parameter name="MCParticleInputCollectionName" type="string" lcioInType="McParticle">MCPhysicsParticles</parameter>
+  <!-- flag to ignore all neutrinos for GenJet filling-->
+  <parameter name="ignoreNeutrinosInMCJets" type="bool">true</parameter>
+  <!-- flag to veto all stable daughters of all vector boson leptons including neutrinos before MCTruthJet filling-->
+  <parameter name="vetoBosonLeptons" type="bool">false</parameter>
+  <!-- flag to veto PFOs angularly matched to MC e,mu's from vector bosons on RECO level, only then recoparticle jet collection will be filled-->
+  <parameter name="vetoBosonLeptonsOnReco" type="bool">false</parameter>
+  <!-- cosAngle for matching checks of PFOs and gen e and mu's from MC vector bosons, 0.995 corresponds to an angle of 5.7 degrees, veto-cone of 0.10 rad-->
+  <parameter name="cosAngle_pfo_lepton" type="float">0.995</parameter>
+  <!--name of the RecoParticleCollection removingleptons-->
+  <parameter name="RecoParticleNoLeptonCollectionName" type="string" lcioInType="ReconstructedParticle">PandoraPFOsNoLeptons</parameter>
+  <!--Name of the MCParticle input collection-->
+  <parameter name="RecoParticleInputCollectionName" type="string" lcioInType="ReconstructedParticle">TightSelectedPandoraPFOs</parameter>
+</processor>
+
+
+<processor name="MyFastGenJetProcessor" type="FastJetProcessor">
+  <parameter name="recParticleIn" type="string" lcioInType="ReconstructedParticle"> MCParticlePandoraPFOs </parameter>
+  <!--parameters are R, beta, gamma -->
+  <parameter name="algorithm" type="StringVec"> ValenciaPlugin 0.7 1 1 </parameter>
+  <parameter name="clusteringMode" type="StringVec"> ExclusiveNJets 2 </parameter>
+  <parameter name="recombinationScheme" type="string">E_scheme </parameter>
+  <parameter name="jetOut" type="string" lcioOutType="ReconstructedParticle">GenJet_VLC</parameter>
+  <parameter name="storeParticlesInJets" type="bool">false</parameter>
+  <parameter name="recParticleOut" type="string" lcioOutType="ReconstructedParticle">MCParticlePandoraPFOsInJet </parameter>
+</processor>
+
+<processor name="MyFastRecoJetProcessor" type="FastJetProcessor">
+  <parameter name="recParticleIn" type="string" lcioInType="ReconstructedParticle"> PandoraPFOsNoLeptons </parameter>
+  <!--parameters are R, beta, gamma -->
+  <parameter name="algorithm" type="StringVec"> ValenciaPlugin 0.7 1 1 </parameter>
+  <parameter name="clusteringMode" type="StringVec"> ExclusiveNJets 2 </parameter>
+  <parameter name="recombinationScheme" type="string">E_scheme </parameter>
+  <parameter name="jetOut" type="string" lcioOutType="ReconstructedParticle">RecoJet_VLC</parameter>
+  <parameter name="storeParticlesInJets" type="bool">false</parameter>
+  <parameter name="recParticleOut" type="string" lcioOutType="ReconstructedParticle"> PandoraPFOsNoLeptonsInJets </parameter>
+</processor>
+
+<processor name="MyLCIOOutputProcessor" type="LCIOOutputProcessor">
+ <!--Writes the current event to the specified LCIO outputfile.eeds to be the last ActiveProcessor.-->
+  <!--drops the named collections from the event-->
+  <!--parameter name="DropCollectionNames" type="StringVec">TPCHits HCalHits  </parameter-->
+  <!--drops all collections of the given type from the event-->
+  <!--parameter name="DropCollectionTypes" type="StringVec">SimTrackerHit SimCalorimeterHit  </parameter-->
+  <!-- write complete objects in subset collections to the file (i.e. ignore subset flag)-->
+  <!--parameter name="FullSubsetCollections" type="StringVec">MCParticlesSkimmed  </parameter-->
+  <!--force keep of the named collections - overrules DropCollectionTypes (and DropCollectionNames)-->
+  <!--parameter name="KeepCollectionNames" type="StringVec">MyPreciousSimTrackerHits  </parameter-->
+  <!-- name of output file -->
+  <parameter name="LCIOOutputFile" type="string">outputfile_testthings.slcio</parameter>
+  <!--write mode for output file:  WRITE_APPEND or WRITE_OLD-->
+  <parameter name="LCIOWriteMode" type="string">WRITE_NEW</parameter>
+  <!--will split output file if size in kB exceeds given value - doesn't work with APPEND and OLD-->
+  <!--parameter name="SplitFileSizekB" type="int">1992294 </parameter-->
+  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+</processor>
+
+
+</marlin>


### PR DESCRIPTION
BEGINRELEASENOTES
- 1. JetAnalyzer for Jet and missing (transverse) energy studies
- 2. TrueMCintoRecoForJets MCParticle and ReconstructedParticle for jets selector, giving functionality to select different input particles
    a) options for MC particles: stable particles, including all neutrinos, including all neutrinos from hadronic decays
   b) remove reconstructed particles after angular matching to leptons from vector boson decays

ENDRELEASENOTES