### PR TITLE
Adapt xml files to have correct parameters in ClonesAndSplitTracksFinder

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -504,10 +504,16 @@
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>
     <parameter name="extrapolateForward" type="bool"> true </parameter>
-    <parameter name="maxDeltaTheta" type="double"> 0.59 </parameter>
-    <parameter name="maxDeltaPhi" type="double"> 0.99 </parameter>
-    <parameter name="maxDeltaPt" type="double"> 0.69 </parameter>
-    <parameter name="mergeSplitTracks" type="bool"> false </parameter>
+    <!--if true, the merging of split tracks is performed-->
+    <parameter name="mergeSplitTracks" type="bool">true  </parameter>
+    <!--minimum track pt for merging (in GeV/c)-->
+    <parameter name="minTrackPt" type="double">1 </parameter>
+    <!--maximum significance separation in phi-->
+    <parameter name="maxSignificancePhi" type="double">3 </parameter>
+    <!--maximum significance separation in pt-->
+    <parameter name="maxSignificancePt" type="double">2 </parameter>
+    <!--maximum significance separation in tanLambda-->
+    <parameter name="maxSignificanceTheta" type="double">3 </parameter>
   </processor>
 
 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -419,10 +419,16 @@
     <parameter name="EnergyLossOn" type="bool"> true </parameter>
     <parameter name="SmoothOn" type="bool"> false </parameter>
     <parameter name="extrapolateForward" type="bool"> true </parameter>
-    <parameter name="maxDeltaTheta" type="double"> 0.59 </parameter>
-    <parameter name="maxDeltaPhi" type="double"> 0.99 </parameter>
-    <parameter name="maxDeltaPt" type="double"> 0.69 </parameter>
-    <parameter name="mergeSplitTracks" type="bool"> false </parameter>
+    <!--if true, the merging of split tracks is performed-->
+    <parameter name="mergeSplitTracks" type="bool">false </parameter>
+    <!--minimum track pt for merging (in GeV/c)-->
+    <parameter name="minTrackPt" type="double">1 </parameter>
+    <!--maximum significance separation in phi-->
+    <parameter name="maxSignificancePhi" type="double">3 </parameter>
+    <!--maximum significance separation in pt-->
+    <parameter name="maxSignificancePt" type="double">2 </parameter>
+    <!--maximum significance separation in tanLambda-->
+    <parameter name="maxSignificanceTheta" type="double">3 </parameter>
   </processor>
 
   <processor name="Refit" type="RefitFinal">


### PR DESCRIPTION
BEGINRELEASENOTES

- Adapt `fcc-` and `clicReconstruction.xml` according to the [PR#45 in MarlinTrkProcessors](https://github.com/iLCSoft/MarlinTrkProcessors/pull/45)
- `mergeSplitTracks` is set to true in the case of `clicReconstruction.xml`

ENDRELEASENOTES