### PR TITLE
Clic steer

### DIFF
--- a/clicConfig/clicReconstruction.xml
+++ b/clicConfig/clicReconstruction.xml
@@ -130,7 +130,7 @@
 
   <global>
     <parameter name="LCIOInputFiles">
-      /eos/experiment/clicdp/grid/ilc/user/w/webermat/ddsimstdhep/ILC17-11-09_gcc62_CLIC_o3_v13/Zuds3000_split100/ddsim_ILC171109_gcc62_Zuds3000_CLIC_o3_v13_00_0.slcio
+      /run/simulation/with/ctest/to/create/a/file.slcio
     </parameter>
     <!-- Limit the number of processed records (run+evt): -->
     <parameter name="MaxRecordNumber" value="-1" />
@@ -146,7 +146,7 @@
     <!--Name of the DD4hep compact xml file to load-->
     <parameter name="EncodingStringParameter"> GlobalTrackerReadoutID </parameter>
     <parameter name="DD4hepXMLFile" type="string">
-      /cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v13/CLIC_o3_v13.xml
+      /cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml
     </parameter>
   </processor>
 

--- a/clicConfig/clic_steer.py
+++ b/clicConfig/clic_steer.py
@@ -210,7 +210,7 @@ SIM.physics.list = "FTFP_BERT"
 
 ##  location of particle.tbl file containing extra particles and their lifetime information
 ##     
-SIM.physics.pdgfile = os.path.join( os.environ.get("DD4HEP"), "DDG4/examples/particle.tbl" )
+SIM.physics.pdgfile = os.path.join( os.environ.get("DD4hepINSTALL"), "examples/DDG4/examples/particle.tbl" )
 
 ##  The global geant4 rangecut for secondary production
 ## 

--- a/fcceeConfig/fccReconstruction.xml
+++ b/fcceeConfig/fccReconstruction.xml
@@ -89,7 +89,7 @@
 
   <global>
     <parameter name="LCIOInputFiles">
-      /afs/cern.ch/work/e/eleogran/public/mu_sim/mu_validation_50kevents.slcio
+      /run/simulation/with/ctest/to/create/a/file.slcio
     </parameter>
     <!-- Limit the number of processed records (run+evt): -->
     <parameter name="MaxRecordNumber" value="-1" />

--- a/fcceeConfig/fcc_steer.py
+++ b/fcceeConfig/fcc_steer.py
@@ -210,7 +210,7 @@ SIM.physics.list = "FTFP_BERT"
 
 ##  location of particle.tbl file containing extra particles and their lifetime information
 ##     
-SIM.physics.pdgfile = os.path.join( os.environ.get("DD4HEP"), "DDG4/examples/particle.tbl" )
+SIM.physics.pdgfile = os.path.join( os.environ.get("DD4hepINSTALL"), "examples/DDG4/examples/particle.tbl" )
 
 ##  The global geant4 rangecut for secondary production
 ## 


### PR DESCRIPTION

BEGINRELEASENOTES
- CLIC Simulation: change the path to the particle.tbl file
- FCC Simulation: change the path to the particle.tbl file
- CLIC Reconstruction: change path of default detector and input file, fixes #131 
- FCC Reconstruction: change path of default  input file, fixes #131 

ENDRELEASENOTES