### PR TITLE
Fix tests

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 SET( test_name "test_CLIC_o2_v04_sim" )
 ADD_TEST( NAME t_${test_name}
-  COMMAND "run_test_k4geo.sh"
-  ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --runType=batch -G -N=100 --outputFile=testCLIC_o2_v04.slcio --gun.isotrop=true --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../clicConfig/clic_steer.py
+  COMMAND ddsim --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/CLIC_o2_v04/CLIC_o2_v04.xml --runType=batch -G -N=100 --outputFile=testCLIC_o2_v04.slcio --gun.isotrop=true --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../clicConfig/clic_steer.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../clicConfig/ CONFIGURATIONS o2_v04
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
@@ -77,8 +76,7 @@ SET(EOS_BACKGROUND_FILE /eos/experiment/clicdp/grid/ilc/prod/clic/3tev/gghad/CLI
 SET(CLIC_DETECTOR_MODEL CLIC_o3_v14)
 SET( test_name "test_${CLIC_DETECTOR_MODEL}_sim" )
 ADD_TEST( NAME t_${test_name}
-  COMMAND "run_test_k4geo.sh"
-  ddsim
+  COMMAND ddsim
   --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
   --runType=batch --inputFile ../Tests/yyxyev_000.stdhep -N 2
   --outputFile=test${CLIC_DETECTOR_MODEL}.slcio
@@ -232,8 +230,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Except
 
 SET( test_name "test_${CLIC_DETECTOR_MODEL}_sim_zuds" )
 ADD_TEST( NAME t_${test_name}
-  COMMAND "run_test_k4geo.sh"
-  ddsim
+  COMMAND ddsim
   --compactFile=$ENV{lcgeo_DIR}/CLIC/compact/${CLIC_DETECTOR_MODEL}/${CLIC_DETECTOR_MODEL}.xml
   --runType=batch -N=4
   --outputFile=test${CLIC_DETECTOR_MODEL}_zuds.slcio
@@ -440,8 +437,7 @@ SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES
 SET(FCCee_DETECTOR_MODEL FCCee_o1_v04)
 SET( test_name "test_${FCCee_DETECTOR_MODEL}_sim" )
 ADD_TEST( NAME t_${test_name}
-  COMMAND "run_test_k4geo.sh"
-  ddsim --compactFile=$ENV{lcgeo_DIR}/FCCee/CLD/compact/${FCCee_DETECTOR_MODEL}/${FCCee_DETECTOR_MODEL}.xml
+  COMMAND ddsim --compactFile=$ENV{lcgeo_DIR}/FCCee/CLD/compact/${FCCee_DETECTOR_MODEL}/${FCCee_DETECTOR_MODEL}.xml
   --runType=batch --inputFiles ../Tests/yyxyev_000.stdhep -N 2
   --outputFile=test${FCCee_DETECTOR_MODEL}.slcio --gun.isotrop=true --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../fcceeConfig/fcc_steer.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../fcceeConfig/

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -82,6 +82,7 @@ ADD_TEST( NAME t_${test_name}
   --outputFile=test${CLIC_DETECTOR_MODEL}.slcio
   --gun.isotrop=true
   --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../clicConfig/clic_steer.py
+  --physics.ESeverity IgnoreTheIssue
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../clicConfig/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION  "Exception;EXCEPTION;ERROR;Error" )
@@ -440,6 +441,7 @@ ADD_TEST( NAME t_${test_name}
   COMMAND ddsim --compactFile=$ENV{lcgeo_DIR}/FCCee/CLD/compact/${FCCee_DETECTOR_MODEL}/${FCCee_DETECTOR_MODEL}.xml
   --runType=batch --inputFiles ../Tests/yyxyev_000.stdhep -N 2
   --outputFile=test${FCCee_DETECTOR_MODEL}.slcio --gun.isotrop=true --steeringFile=${CMAKE_CURRENT_SOURCE_DIR}/../fcceeConfig/fcc_steer.py
+  --physics.ESeverity IgnoreTheIssue
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../fcceeConfig/
   )
 SET_TESTS_PROPERTIES( t_${test_name} PROPERTIES


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix tests by not using `run_test_k4geo` (removed in https://github.com/key4hep/k4geo/pull/502) and also ignoring the warnings about mass differences for unstable particles 

ENDRELEASENOTES

I couldn't find any more occurrences of `run_test_k4geo` in iLCSoft.

The warnings look like (I think this is for CLIC_o3_v14):

```
-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=-10513 deltaMass(MeV)=4.4689 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=5725.53 while PDG mass(MEV)=5730
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=10221 deltaMass(MeV)=400 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=1000 while PDG mass(MEV)=1400
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=-213 deltaMass(MeV)=116.751 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=892.551 while PDG mass(MEV)=775.8
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=-10211 deltaMass(MeV)=439.633 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=999.367 while PDG mass(MEV)=1439
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=20113 deltaMass(MeV)=280.068 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=949.932 while PDG mass(MEV)=1230
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=331 deltaMass(MeV)=1.20556 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=956.574 while PDG mass(MEV)=957.78
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=-213 deltaMass(MeV)=28.3756 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=747.424 while PDG mass(MEV)=775.8
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=10213 deltaMass(MeV)=33.3263 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=1262.83 while PDG mass(MEV)=1229.5
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------


-------- WWWW ------- G4Exception-START -------- WWWW -------
*** G4Exception : part0005
      issued by : G4PrimaryParticle::Set4Momentum
Primary particle PDG=10313 deltaMass(MeV)=40.412 is larger than the tolerance(MeV)=1
 Specified mass(MeV)=1293.41 while PDG mass(MEV)=1253
 To change the tolerance or the exception severity, use G4PrimaryTransformer::SetKETolerance() method.
*** This is just a warning message. ***
-------- WWWW -------- G4Exception-END --------- WWWW -------

```

Tests on Alma 9:
```
    Start 1: t_test_CLIC_o3_v14_sim
    Start 4: t_test_FCCee_o1_v04_sim
1/5 Test #1: t_test_CLIC_o3_v14_sim ...............   Passed   80.67 sec
    Start 2: t_test_CLIC_o3_v14_reco_conformal
2/5 Test #4: t_test_FCCee_o1_v04_sim ..............   Passed  121.71 sec
    Start 5: t_test_FCCee_o1_v04_reco_conformal
3/5 Test #2: t_test_CLIC_o3_v14_reco_conformal ....   Passed   44.09 sec
    Start 3: t_test_CLIC_o3_v14_vtx_makentp
4/5 Test #3: t_test_CLIC_o3_v14_vtx_makentp .......   Passed   38.60 sec
5/5 Test #5: t_test_FCCee_o1_v04_reco_conformal ...   Passed   83.76 sec
```