### PR TITLE
Make sure DetTypes are defined

### DIFF
--- a/Visualisation/CLIC_o3_v06_CED/CLIC_o3_v06_CED.xml
+++ b/Visualisation/CLIC_o3_v06_CED/CLIC_o3_v06_CED.xml
@@ -217,6 +217,8 @@
         <vis name="LCALVis"  alpha="1.0" r="1.00" g="0.68"  b="0.31" showDaughters="true"  visible="true"/>
         <vis name="BCALVis"  alpha="1.0" r="1.00" g="0.49"  b="0.17" showDaughters="true"  visible="true"/>
     </display>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
     
     <include ref="Materials_v01.xml"/>
     


### PR DESCRIPTION
Otherwise laoding will fail after
https://github.com/AIDASoft/DD4hep/pull/1578 because the exception that was previously silently swallowed no longer is



BEGINRELEASENOTES
- Make sure that the `DetType`s are defined in the CLIC visualization geometry to avoid failing to load the geometry with newer versions of DD4hep

ENDRELEASENOTES