### PR TITLE
Add a check for when there isn't a trackerHitRelationCollection

### DIFF
--- a/Tracking/src/ClicEfficiencyCalculator.cc
+++ b/Tracking/src/ClicEfficiencyCalculator.cc
@@ -332,7 +332,8 @@ void ClicEfficiencyCalculator::processEvent( LCEvent* evt ) {
     // Get the collection of tracker hit relations
     LCCollection* trackerHitRelationCollection = 0 ;
     getCollection(trackerHitRelationCollection, m_inputTrackerHitRelationCollections[collection], evt);
-    
+    if(trackerHitRelationCollection == 0) continue;
+
     // Create the relations navigator
     std::shared_ptr<LCRelationNavigator> relation =
       std::make_shared<LCRelationNavigator>( LCRelationNavigator( trackerHitRelationCollection ) );


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a check for when there isn't a trackerHitRelationCollection, like for all the other collections

ENDRELEASENOTES

A crash came up in the FCC Full Sim meeting: https://indico.cern.ch/event/1676587/contributions/7055559/attachments/3265903/5832831/FCC_Full-SIMMeeting_29_04_26.pdf
Having a look at the stack trace (backup of the slides), it could be a dereference of a nullptr, and this is the only collection that is not being checked. So this may be a good improvement by itself.

@jessy-daniel, do you think this could be the fix? (what does your digitizer change in terms of output collections compared to DDPlanarDigi?) You could test it locally by building this package, then running `k4_local_repo` if you are using the stack. We also have a debug build if you pass `-d` when sourcing the setup script in the stack. It will be much slower, but if it crashes it will give us the line number in the file.